### PR TITLE
[2-1] 유저 회원가입 프로필 이미지

### DIFF
--- a/app/src/main/java/com/ariari/mowoori/data/repository/IntroRepository.kt
+++ b/app/src/main/java/com/ariari/mowoori/data/repository/IntroRepository.kt
@@ -1,8 +1,7 @@
 package com.ariari.mowoori.data.repository
 
-import androidx.lifecycle.LiveData
-import com.ariari.mowoori.util.Event
-import com.google.firebase.database.DataSnapshot
+import android.net.Uri
+import com.ariari.mowoori.ui.register.entity.UserInfo
 
 interface IntroRepository {
     suspend fun checkUserRegistered(userUid: String): Boolean
@@ -11,5 +10,7 @@ interface IntroRepository {
 
     fun getUserUid(): String?
 
-    suspend fun userRegister(nickname: String): Boolean
+    suspend fun userRegister(userInfo: UserInfo): Boolean
+
+    suspend fun putUserProfile(uri: Uri): String
 }

--- a/app/src/main/java/com/ariari/mowoori/data/repository/IntroRepositoryImpl.kt
+++ b/app/src/main/java/com/ariari/mowoori/data/repository/IntroRepositoryImpl.kt
@@ -1,5 +1,6 @@
 package com.ariari.mowoori.data.repository
 
+import android.net.Uri
 import com.ariari.mowoori.ui.register.entity.UserInfo
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.database.DatabaseReference
@@ -32,11 +33,18 @@ class IntroRepositoryImpl @Inject constructor(
         return firebaseAuth.currentUser?.uid
     }
 
-    override suspend fun userRegister(nickname: String): Boolean {
+    override suspend fun userRegister(userInfo: UserInfo): Boolean {
         getUserUid()?.let {
-            val userInfo = UserInfo(nickname)
             firebaseReference.child("users").child(it).setValue(userInfo)
             return true
         } ?: run { return false }
+    }
+
+    override suspend fun putUserProfile(uri: Uri): String {
+        val uid = getUserUid()
+        val ref = storageReference.child("images/$uid/${uri.lastPathSegment}")
+        val task = ref.putFile(uri).await()
+        val uploadUrl = task.storage.downloadUrl.await()
+        return uploadUrl.toString()
     }
 }

--- a/app/src/main/java/com/ariari/mowoori/ui/register/RegisterActivity.kt
+++ b/app/src/main/java/com/ariari/mowoori/ui/register/RegisterActivity.kt
@@ -2,13 +2,22 @@ package com.ariari.mowoori.ui.register
 
 import android.content.Intent
 import android.os.Bundle
+import android.util.Log.e
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
 import com.ariari.mowoori.R
 import com.ariari.mowoori.databinding.ActivityRegisterBinding
 import com.ariari.mowoori.ui.main.MainActivity
 import com.ariari.mowoori.util.EventObserver
+import com.ariari.mowoori.util.TimberUtil
 import com.ariari.mowoori.util.toastMessage
+import com.bumptech.glide.Glide
+import com.bumptech.glide.load.resource.bitmap.CenterCrop
+import com.bumptech.glide.load.resource.bitmap.RoundedCorners
+import com.bumptech.glide.request.RequestOptions
+import com.google.firebase.ktx.Firebase
+import com.google.firebase.storage.ktx.storage
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
@@ -18,11 +27,17 @@ class RegisterActivity : AppCompatActivity() {
     private val binding by lazy {
         ActivityRegisterBinding.inflate(layoutInflater)
     }
+    private val getContent = registerForActivityResult(ActivityResultContracts.GetContent()) {
+        it?.let {
+            viewModel.setProfileImage(it)
+        }
+    }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(binding.root)
         binding.viewModel = viewModel
+        binding.lifecycleOwner = this
         setObservers()
         viewModel.createNickName()
     }
@@ -30,6 +45,7 @@ class RegisterActivity : AppCompatActivity() {
     private fun setObservers() {
         setInvalidNickNameObserver()
         setRegisterSuccessObserver()
+        setProfileClickObserver()
     }
 
     private fun setInvalidNickNameObserver() {
@@ -45,6 +61,12 @@ class RegisterActivity : AppCompatActivity() {
             } else {
                 toastMessage(getString(R.string.register_fail_msg))
             }
+        })
+    }
+
+    private fun setProfileClickObserver() {
+        viewModel.profileImageClickEvent.observe(this, EventObserver {
+            getContent.launch("image/*")
         })
     }
 

--- a/app/src/main/java/com/ariari/mowoori/ui/register/RegisterActivity.kt
+++ b/app/src/main/java/com/ariari/mowoori/ui/register/RegisterActivity.kt
@@ -2,7 +2,6 @@ package com.ariari.mowoori.ui.register
 
 import android.content.Intent
 import android.os.Bundle
-import android.util.Log.e
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
@@ -10,14 +9,8 @@ import com.ariari.mowoori.R
 import com.ariari.mowoori.databinding.ActivityRegisterBinding
 import com.ariari.mowoori.ui.main.MainActivity
 import com.ariari.mowoori.util.EventObserver
-import com.ariari.mowoori.util.TimberUtil
 import com.ariari.mowoori.util.toastMessage
-import com.bumptech.glide.Glide
-import com.bumptech.glide.load.resource.bitmap.CenterCrop
-import com.bumptech.glide.load.resource.bitmap.RoundedCorners
-import com.bumptech.glide.request.RequestOptions
-import com.google.firebase.ktx.Firebase
-import com.google.firebase.storage.ktx.storage
+import com.ariari.mowoori.widget.ProgressDialogManager
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
@@ -46,6 +39,7 @@ class RegisterActivity : AppCompatActivity() {
         setInvalidNickNameObserver()
         setRegisterSuccessObserver()
         setProfileClickObserver()
+        setLoadingEventObserver()
     }
 
     private fun setInvalidNickNameObserver() {
@@ -56,6 +50,7 @@ class RegisterActivity : AppCompatActivity() {
 
     private fun setRegisterSuccessObserver() {
         viewModel.registerSuccessEvent.observe(this, EventObserver {
+            ProgressDialogManager.instance.clear()
             if (it) {
                 moveToMain()
             } else {
@@ -67,6 +62,16 @@ class RegisterActivity : AppCompatActivity() {
     private fun setProfileClickObserver() {
         viewModel.profileImageClickEvent.observe(this, EventObserver {
             getContent.launch("image/*")
+        })
+    }
+
+    private fun setLoadingEventObserver() {
+        viewModel.loadingEvent.observe(this,EventObserver{
+            if(it){
+                ProgressDialogManager.instance.show(this)
+            }else{
+                ProgressDialogManager.instance.clear()
+            }
         })
     }
 

--- a/app/src/main/java/com/ariari/mowoori/ui/register/RegisterViewModel.kt
+++ b/app/src/main/java/com/ariari/mowoori/ui/register/RegisterViewModel.kt
@@ -30,6 +30,9 @@ class RegisterViewModel @Inject constructor(
     private val _profileImageUri = MutableLiveData<Uri>()
     val profileImageUri: LiveData<Uri> = _profileImageUri
 
+    private val _loadingEvent = MutableLiveData<Event<Boolean>>()
+    val loadingEvent: LiveData<Event<Boolean>> = _loadingEvent
+
     fun createNickName() {
         viewModelScope.launch {
             val nickname = introRepository.getRandomNickName()
@@ -46,6 +49,7 @@ class RegisterViewModel @Inject constructor(
     }
 
     fun clickComplete() {
+        _loadingEvent.value = Event(true)
         val nickname = profileText.get() ?: ""
         if (!checkNicknameValid(nickname)) {
             _invalidNicknameEvent.value = Event(Unit)

--- a/app/src/main/java/com/ariari/mowoori/ui/register/RegisterViewModel.kt
+++ b/app/src/main/java/com/ariari/mowoori/ui/register/RegisterViewModel.kt
@@ -1,16 +1,14 @@
 package com.ariari.mowoori.ui.register
 
+import android.net.Uri
 import androidx.databinding.ObservableField
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.ariari.mowoori.data.repository.IntroRepository
+import com.ariari.mowoori.ui.register.entity.UserInfo
 import com.ariari.mowoori.util.Event
-import com.google.firebase.auth.FirebaseAuth
-import com.google.firebase.database.DatabaseReference
-import com.google.firebase.database.ktx.database
-import com.google.firebase.ktx.Firebase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -26,6 +24,12 @@ class RegisterViewModel @Inject constructor(
     private val _registerSuccessEvent = MutableLiveData<Event<Boolean>>()
     val registerSuccessEvent: LiveData<Event<Boolean>> = _registerSuccessEvent
 
+    private val _profileImageClickEvent = MutableLiveData<Event<Unit>>()
+    val profileImageClickEvent: LiveData<Event<Unit>> = _profileImageClickEvent
+
+    private val _profileImageUri = MutableLiveData<Uri>()
+    val profileImageUri: LiveData<Uri> = _profileImageUri
+
     fun createNickName() {
         viewModelScope.launch {
             val nickname = introRepository.getRandomNickName()
@@ -34,8 +38,11 @@ class RegisterViewModel @Inject constructor(
     }
 
     fun clickProfile() {
-        // TODO: 2021/11/04 이미지 가져오기
-        val imageUri = ""
+        _profileImageClickEvent.value = Event(Unit)
+    }
+
+    fun setProfileImage(uri: Uri) {
+        _profileImageUri.postValue(uri)
     }
 
     fun clickComplete() {
@@ -45,7 +52,16 @@ class RegisterViewModel @Inject constructor(
             return
         }
         viewModelScope.launch {
-            val success = introRepository.userRegister(nickname)
+            var uploadUrl = ""
+            profileImageUri.value?.let {
+                uploadUrl = introRepository.putUserProfile(it)
+            }
+            val success = introRepository.userRegister(
+                UserInfo(
+                    nickname = nickname,
+                    profileImage = uploadUrl
+                )
+            )
             _registerSuccessEvent.value = Event(success)
         }
     }

--- a/app/src/main/java/com/ariari/mowoori/ui/register/entity/User.kt
+++ b/app/src/main/java/com/ariari/mowoori/ui/register/entity/User.kt
@@ -7,5 +7,6 @@ data class User(
 
 data class UserInfo(
     val nickname: String,
+    val profileImage: String,
     val groupList: List<String> = emptyList()
 )

--- a/app/src/main/java/com/ariari/mowoori/util/BindingAdapters.kt
+++ b/app/src/main/java/com/ariari/mowoori/util/BindingAdapters.kt
@@ -1,4 +1,25 @@
 package com.ariari.mowoori.util
 
+import android.net.Uri
+import android.widget.ImageView
+import androidx.databinding.BindingAdapter
+import com.bumptech.glide.Glide
+import com.bumptech.glide.request.RequestOptions
+
 object BindingAdapters {
+
+    @BindingAdapter(value = ["imageUri", "isCircle"], requireAll = false)
+    @JvmStatic
+    fun bindImageUri(
+        imageView: ImageView,
+        uri: Uri?,
+        isCircle: Boolean = false,
+    ) {
+        uri?.let {
+            var builder = Glide.with(imageView).load(it)
+            if (isCircle)
+                builder = builder.apply(RequestOptions.circleCropTransform())
+            builder.into(imageView)
+        }
+    }
 }

--- a/app/src/main/java/com/ariari/mowoori/widget/ProgressDialogManager.kt
+++ b/app/src/main/java/com/ariari/mowoori/widget/ProgressDialogManager.kt
@@ -1,0 +1,48 @@
+package com.ariari.mowoori.widget
+
+import android.app.Dialog
+import android.content.Context
+import android.os.Bundle
+import com.ariari.mowoori.R
+import com.ariari.mowoori.util.TimberUtil
+
+class ProgressDialogManager {
+    private var progressDialog: ProgressDialog? = null
+
+    @Synchronized
+    fun show(context: Context) {
+        try {
+            if (progressDialog != null) {
+                progressDialog?.dismiss()
+            }
+            progressDialog = ProgressDialog(context)
+            progressDialog?.show()
+        } catch (e: Exception) {
+            TimberUtil.timber("ProgressDialogManager","clear: $e")
+        }
+    }
+
+    @Synchronized
+    fun clear() {
+        try {
+            if (progressDialog != null) {
+                progressDialog?.dismiss()
+                progressDialog = null
+            }
+        } catch (e: Exception) {
+            TimberUtil.timber("ProgressDialogManager","clear: $e")
+        }
+    }
+
+    inner class ProgressDialog(context: Context) : Dialog(context,R.style.DialogTheme ) {
+        override fun onCreate(savedInstanceState: Bundle?) {
+            super.onCreate(savedInstanceState)
+            setContentView(R.layout.dialog_progress)
+            setCancelable(false)
+        }
+    }
+
+    companion object {
+        val instance = ProgressDialogManager()
+    }
+}

--- a/app/src/main/res/drawable/ic_snow_head.xml
+++ b/app/src/main/res/drawable/ic_snow_head.xml
@@ -1,0 +1,36 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="222dp"
+    android:height="209dp"
+    android:viewportWidth="222"
+    android:viewportHeight="209">
+  <path
+      android:pathData="M0.636,104.314a110.682,104.024 0,1 0,221.364 0a110.682,104.024 0,1 0,-221.364 0z"
+      android:fillColor="#ffffff"/>
+  <path
+      android:pathData="M190.464,124.205L106.753,135.173L106.908,112.111L190.464,124.205Z"
+      android:fillColor="#FFF50A"/>
+  <path
+      android:pathData="M48.499,41.241C56.31,47.159 66.505,53.121 73.421,59.173C76.592,61.947 101.125,63.685 95.608,69.203C87.345,77.465 68.008,83.975 56.705,87.742"
+      android:strokeWidth="3"
+      android:fillColor="#00000000"
+      android:strokeColor="#000000"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M48.499,65.86C62.124,68.519 73.252,71.331 86.794,71.331"
+      android:strokeWidth="3"
+      android:fillColor="#00000000"
+      android:strokeColor="#000000"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M155.178,41.241C142.665,48.566 135.456,51.238 125.697,60.997C119.79,66.904 111.851,64.888 120.986,69.963C133.539,76.937 148.646,79.74 160.649,87.742"
+      android:strokeWidth="3"
+      android:fillColor="#00000000"
+      android:strokeColor="#000000"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M116.883,65.86H155.178"
+      android:strokeWidth="3"
+      android:fillColor="#00000000"
+      android:strokeColor="#000000"
+      android:strokeLineCap="round"/>
+</vector>

--- a/app/src/main/res/drawable/rotate_progress.xml
+++ b/app/src/main/res/drawable/rotate_progress.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<rotate xmlns:android="http://schemas.android.com/apk/res/android"
+    android:fromDegrees="0"
+    android:toDegrees="1440"
+    android:drawable="@drawable/ic_snow_head"
+    android:repeatCount="infinite"
+    android:pivotX="50%"
+    android:pivotY="50%" />

--- a/app/src/main/res/layout/activity_register.xml
+++ b/app/src/main/res/layout/activity_register.xml
@@ -31,13 +31,17 @@
 
         <ImageView
             android:id="@+id/iv_register_profile"
+            imageUri="@{viewModel.profileImageUri}"
+            isCircle="@{true}"
             android:layout_width="134dp"
             android:layout_height="134dp"
             android:layout_marginTop="95dp"
+            android:onClick="@{()->viewModel.clickProfile()}"
             android:src="@drawable/ic_profile_empty"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/tv_register_title" />
+            app:layout_constraintTop_toBottomOf="@id/tv_register_title"
+            android:contentDescription="@string/desc_profile_image" />
 
         <EditText
             android:id="@+id/et_register_nickname"
@@ -49,7 +53,6 @@
             android:autofillHints="username"
             android:background="@null"
             android:gravity="center"
-            android:hint=""
             android:inputType="text"
             android:lines="1"
             android:maxLength="10"
@@ -60,7 +63,8 @@
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/iv_register_profile"
-            tools:text="전설의 코박쥐" />
+            tools:text="전설의 코박쥐"
+            tools:ignore="LabelFor" />
 
         <View
             android:layout_width="0dp"

--- a/app/src/main/res/layout/dialog_progress.xml
+++ b/app/src/main/res/layout/dialog_progress.xml
@@ -1,0 +1,17 @@
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+
+    <ProgressBar
+        android:layout_width="100dp"
+        android:layout_height="100dp"
+        android:layout_gravity="center"
+        android:indeterminateDrawable="@drawable/rotate_progress"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2,11 +2,11 @@
     <string name="app_name">MoWoori</string>
     <string name="binding_error">Binding not initialized to reference the view.</string>
     <string name="nothing">아무것도 없어요</string>
+    <string name="desc_app_logo">앱 로고</string>
 
     <string name="bottom_nav_home">Home</string>
     <string name="bottom_nav_missions">Missions</string>
     <string name="bottom_nav_members">Members</string>
-
     <string name="drawer_header_group_list">그룹 리스트</string>
 
     <!-- Register -->
@@ -14,6 +14,7 @@
     <string name="register_nickname_hint">(1자 이상 10자 이하)</string>
     <string name="register_nickname_error_msg">닉네임을 확인해주세요</string>
     <string name="register_fail_msg">회원가입에 실패했습니다.</string>
+    <string name="desc_profile_image">프로필 이미지</string>
 
     <!-- CustomTitleView -->
     <string name="title_view_back">뒤로가기 타이틀 뷰</string>
@@ -37,12 +38,9 @@
     <string name="group_invite_title">초대코드를\n입력해주세요</string>
     <string name="group_invalid">올바르지 않은 형식입니다.</string>
 
-    <!--description-->
-    <string name="desc_app_logo">앱 로고</string>
     <!--home-->
     <string name="desc_home_snow_face">눈사람 얼굴</string>
     <string name="all_complete">완료</string>
-    <string name="desc_profile_image">프로필 이미지</string>
 
     <!-- MissionsFragment -->
     <string name="item_missions_stamp_count">%d/%d</string>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -14,4 +14,8 @@
         <item name="android:windowLightStatusBar">true</item>
         <!-- Customize your theme here. -->
     </style>
+
+    <style name="DialogTheme" parent="android:Theme.Dialog">
+        <item name="android:windowBackground">@android:color/transparent</item>
+    </style>
 </resources>


### PR DESCRIPTION
# ❗️ 이슈 트래킹
- #3 

# 💡 작업목록
- 회원가입 화면 프로필 추가
   - Firebase Storage 업로드후 이미지url 저장 
- 프로그레스 다이얼로그 추가
   - 프로그레스 이미지는 임의로 붙여놨습니다. 추후에 수정하면 좋을것 같아여! 

https://user-images.githubusercontent.com/49181228/140654043-bea562f4-489f-4879-80b1-a0c1c91cb150.mp4

# ❓ 고민과 해결
### 이미지 업로드시점에 대한 고민
1. 이미지뷰에 붙이는 순간 업로드
2. 회원가입 완료 버튼 클릭시 업로드
1번으로 한다면 불필요한 이미지도 포함될것 같아 2번으로 결정했습니다. 다만 업로드 시간이 좀걸리는 것같아 프로그레스 다이얼로그를 추가했습니다.

### ViewModel 에서의 Uri 객체 관리
핸드폰 로컬 저장소로 부터 ImageUri 를 받아 ImageView 에 띄우게 됩니다. 이때 이 Uri는 ViewModel 에서 관리하고 LiveData 로 Reactive하게 ImageView 에 로드됩니다. Uri를 안드로이드에 의존성을 갖는 Class라 좀 걱정이 됩니다.
Uri를 스트링으로 변환하여 관리하는 방법이 있지만 그렇게 한다면  " Uri.parse(),Uri.toStirng() " 과 같은 파싱코드들이 들어가 오히려불필요한 코드가 들어갈것 같아 Uri 자체로 관리하도록 구현했습니다.

