### PR TITLE
[5-2] 그룹 변경

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -121,6 +121,7 @@ obj/
 .idea/jarRepositories.xml
 .idea/navEditor.xml
 .idea/deploymentTargetDropDown.xml
+.idea/runConfigurations.xml
 
 # OS-specific files
 .DS_Store

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -81,4 +81,7 @@ dependencies {
     implementation "com.google.dagger:hilt-android:$hiltVersion"
     kapt "com.google.dagger:hilt-android-compiler:$hiltVersion"
     kapt "androidx.hilt:hilt-compiler:$hiltCompilerVersion"
+
+    // Gson
+    implementation "com.google.code.gson:gson:$gsonVersion"
 }

--- a/app/src/main/java/com/ariari/mowoori/ui/home/HomeFragment.kt
+++ b/app/src/main/java/com/ariari/mowoori/ui/home/HomeFragment.kt
@@ -20,6 +20,7 @@ import com.ariari.mowoori.R
 import com.ariari.mowoori.databinding.FragmentHomeBinding
 import com.ariari.mowoori.ui.home.adapter.DrawerAdapter
 import com.ariari.mowoori.ui.home.adapter.DrawerAdapterDecoration
+import com.ariari.mowoori.util.EventObserver
 import com.ariari.mowoori.util.TimberUtil
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.Job
@@ -55,6 +56,12 @@ class HomeFragment : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         binding.lifecycleOwner = viewLifecycleOwner
+        // TODO: getUserInfo -> setGroup
+        // TODO: getFirstOrNull
+        // TODO: currentGroup
+        setUserInfo()
+        setUserInfoObserver()
+        setGroupInfoObserver()
         setDrawerOpenListener()
         setDrawerAdapter()
         setRecyclerViewDecoration()
@@ -62,6 +69,23 @@ class HomeFragment : Fragment() {
         setAnimation()
         setClickListener()
         setMenuListener()
+    }
+
+    private fun setUserInfo() {
+        // TODO: 유저아이디는 로컬에서 가져오기 (현재는 더미 데이터 사용)
+        viewModel.setUserInfo()
+    }
+
+    private fun setUserInfoObserver() {
+        viewModel.userInfo.observe(viewLifecycleOwner, EventObserver { userInfo ->
+            viewModel.setCurrentGroup(userInfo)
+        })
+    }
+
+    private fun setGroupInfoObserver() {
+        viewModel.currentGroupInfo.observe(viewLifecycleOwner, { groupInfo ->
+            binding.tbHome.title = groupInfo.groupName
+        })
     }
 
 //    override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {

--- a/app/src/main/java/com/ariari/mowoori/ui/home/HomeFragment.kt
+++ b/app/src/main/java/com/ariari/mowoori/ui/home/HomeFragment.kt
@@ -5,6 +5,7 @@ import android.animation.AnimatorInflater
 import android.animation.AnimatorListenerAdapter
 import android.animation.AnimatorSet
 import android.animation.ObjectAnimator
+import android.content.Context
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -44,6 +45,12 @@ class HomeFragment : Fragment() {
     private lateinit var snowFaceDownAnim: Animator
     private lateinit var snowFaceUpAnim: Animator
 
+    override fun onAttach(context: Context) {
+        super.onAttach(context)
+        // onAttach 콜백함수는 최초 한번만 실행된다.
+        setUserInfo()
+    }
+
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
@@ -57,7 +64,6 @@ class HomeFragment : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         binding.lifecycleOwner = viewLifecycleOwner
-        setUserInfo()
         setUserInfoObserver()
         setCurrentGroupInfoObserver()
         setGroupInfoListObserver()

--- a/app/src/main/java/com/ariari/mowoori/ui/home/HomeFragment.kt
+++ b/app/src/main/java/com/ariari/mowoori/ui/home/HomeFragment.kt
@@ -38,6 +38,7 @@ class HomeFragment : Fragment() {
 
     private val viewModel: HomeViewModel by viewModels()
 
+    private lateinit var adapter: DrawerAdapter
     private var snowJob: Job? = null
     private lateinit var snowFace: ImageView
     private lateinit var snowFaceDownAnim: Animator
@@ -61,7 +62,8 @@ class HomeFragment : Fragment() {
         // TODO: currentGroup
         setUserInfo()
         setUserInfoObserver()
-        setGroupInfoObserver()
+        setCurrentGroupInfoObserver()
+        setGroupInfoListObserver()
         setDrawerOpenListener()
         setDrawerAdapter()
         setRecyclerViewDecoration()
@@ -79,12 +81,20 @@ class HomeFragment : Fragment() {
     private fun setUserInfoObserver() {
         viewModel.userInfo.observe(viewLifecycleOwner, EventObserver { userInfo ->
             viewModel.setCurrentGroup(userInfo)
+            viewModel.setGroupInfoList(userInfo)
         })
     }
 
-    private fun setGroupInfoObserver() {
+    private fun setCurrentGroupInfoObserver() {
         viewModel.currentGroupInfo.observe(viewLifecycleOwner, { groupInfo ->
             binding.tbHome.title = groupInfo.groupName
+        })
+    }
+
+    private fun setGroupInfoListObserver() {
+        viewModel.groupInfoList.observe(viewLifecycleOwner, { groupInfoList ->
+            adapter.groups = groupInfoList
+            adapter.notifyDataSetChanged()
         })
     }
 
@@ -143,15 +153,13 @@ class HomeFragment : Fragment() {
     }
 
     private fun setDrawerAdapter() {
-        val adapter: DrawerAdapter by lazy {
-            DrawerAdapter(object : DrawerAdapter.OnItemClickListener {
-                override fun itemClick(position: Int) {
-                    // TODO: 그룹 이동
-                    // TODO: 그룹 아이템 배경 색상 변경
-                    binding.drawerHome.close()
-                }
-            })
-        }
+        adapter = DrawerAdapter(object : DrawerAdapter.OnItemClickListener {
+            override fun itemClick(position: Int) {
+                // TODO: 그룹 이동
+                // TODO: 그룹 아이템 배경 색상 변경
+                binding.drawerHome.close()
+            }
+        })
         binding.rvDrawer.adapter = adapter
     }
 

--- a/app/src/main/java/com/ariari/mowoori/ui/home/HomeFragment.kt
+++ b/app/src/main/java/com/ariari/mowoori/ui/home/HomeFragment.kt
@@ -57,9 +57,6 @@ class HomeFragment : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         binding.lifecycleOwner = viewLifecycleOwner
-        // TODO: getUserInfo -> setGroup
-        // TODO: getFirstOrNull
-        // TODO: currentGroup
         setUserInfo()
         setUserInfoObserver()
         setCurrentGroupInfoObserver()
@@ -80,7 +77,6 @@ class HomeFragment : Fragment() {
 
     private fun setUserInfoObserver() {
         viewModel.userInfo.observe(viewLifecycleOwner, EventObserver { userInfo ->
-            viewModel.setCurrentGroup(userInfo)
             viewModel.setGroupInfoList(userInfo)
         })
     }
@@ -155,8 +151,7 @@ class HomeFragment : Fragment() {
     private fun setDrawerAdapter() {
         adapter = DrawerAdapter(object : DrawerAdapter.OnItemClickListener {
             override fun itemClick(position: Int) {
-                // TODO: 그룹 이동
-                // TODO: 그룹 아이템 배경 색상 변경
+                viewModel.setCurrentGroupInfo(position)
                 binding.drawerHome.close()
             }
         })

--- a/app/src/main/java/com/ariari/mowoori/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/com/ariari/mowoori/ui/home/HomeViewModel.kt
@@ -4,9 +4,7 @@ import android.animation.Animator
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
-import com.ariari.mowoori.ui.home.entity.Group
 import com.ariari.mowoori.ui.home.entity.GroupInfo
-import com.ariari.mowoori.ui.register.entity.User
 import com.ariari.mowoori.ui.register.entity.UserInfo
 import com.ariari.mowoori.util.Event
 import com.google.firebase.database.FirebaseDatabase
@@ -23,6 +21,10 @@ class HomeViewModel : ViewModel() {
 
     private val _currentGroupInfo = MutableLiveData<GroupInfo>()
     val currentGroupInfo: LiveData<GroupInfo> = _currentGroupInfo
+
+    private val mutableGroupList = mutableListOf<GroupInfo>()
+    private val _groupInfoList = MutableLiveData<List<GroupInfo>>()
+    val groupInfoList: LiveData<List<GroupInfo>> = _groupInfoList
 
     private var _isSnowing = MutableLiveData<Boolean>()
     val isSnowing: LiveData<Boolean> = _isSnowing
@@ -54,6 +56,17 @@ class HomeViewModel : ViewModel() {
             _currentGroupInfo.value = groupInfo
         }.addOnFailureListener {
             // TODO: 실패처리
+        }
+    }
+
+    fun setGroupInfoList(userInfo: UserInfo) {
+        userInfo.groupList.forEach { groupId ->
+            databaseReference.child("groups").child(groupId).get().addOnSuccessListener {
+                val groupInfoJson = it.value ?: return@addOnSuccessListener
+                val groupInfo = gson.fromJson(groupInfoJson.toString(), GroupInfo::class.java)
+                mutableGroupList.add(groupInfo)
+                _groupInfoList.value = mutableGroupList
+            }
         }
     }
 

--- a/app/src/main/java/com/ariari/mowoori/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/com/ariari/mowoori/ui/home/HomeViewModel.kt
@@ -46,28 +46,31 @@ class HomeViewModel : ViewModel() {
         }
     }
 
-    fun setCurrentGroup(userInfo: UserInfo) {
-        // 처음 선택되는 그룹은 항상 첫번째 그룹
-        val firstGroupId = userInfo.groupList.firstOrNull() ?: return
-        // TODO: 레포지토리에서 실행되는 코드
-        databaseReference.child("groups").child(firstGroupId).get().addOnSuccessListener {
-            val groupInfoJson = it.value ?: return@addOnSuccessListener
-            val groupInfo = gson.fromJson(groupInfoJson.toString(), GroupInfo::class.java)
-            _currentGroupInfo.value = groupInfo
-        }.addOnFailureListener {
-            // TODO: 실패처리
-        }
-    }
-
     fun setGroupInfoList(userInfo: UserInfo) {
-        userInfo.groupList.forEach { groupId ->
+        userInfo.groupList.forEachIndexed { index, groupId ->
             databaseReference.child("groups").child(groupId).get().addOnSuccessListener {
                 val groupInfoJson = it.value ?: return@addOnSuccessListener
                 val groupInfo = gson.fromJson(groupInfoJson.toString(), GroupInfo::class.java)
+                if (index == 0) {
+                    groupInfo.selected = true
+                    _currentGroupInfo.value = groupInfo
+                }
                 mutableGroupList.add(groupInfo)
                 _groupInfoList.value = mutableGroupList
+            }.addOnFailureListener {
+                // TODO: 실패처리
             }
         }
+    }
+
+    fun setCurrentGroupInfo(position: Int) {
+        mutableGroupList.forEach { groupInfo ->
+            groupInfo.selected = false
+        }
+        // 헤더를 포함한 위치 값이기 떄문에 -1 을 해주어야 한다.
+        mutableGroupList[position - 1].selected = true
+        _groupInfoList.value = mutableGroupList
+        _currentGroupInfo.value = mutableGroupList[position - 1]
     }
 
     fun updateIsSnowing() {

--- a/app/src/main/java/com/ariari/mowoori/ui/home/adapter/DrawerAdapter.kt
+++ b/app/src/main/java/com/ariari/mowoori/ui/home/adapter/DrawerAdapter.kt
@@ -44,12 +44,8 @@ class DrawerAdapter(private val listener: OnItemClickListener) :
 
     override fun onBindViewHolder(holder: RecyclerView.ViewHolder, position: Int) {
         when (holder) {
-            is HeaderViewHolder -> {
-                // nothing to bind
-            }
-            else -> {
-                (holder as GroupViewHolder).bind(groups[position - 1])
-            }
+            is HeaderViewHolder -> Unit // nothing to bind
+            else -> (holder as GroupViewHolder).bind(groups[position - 1])
         }
     }
 
@@ -75,12 +71,11 @@ class DrawerAdapter(private val listener: OnItemClickListener) :
 
         fun bind(groupInfo: GroupInfo) {
             binding.tvDrawerGroupName.text = groupInfo.groupName
+            if (groupInfo.selected) {
+                binding.root.setBackgroundResource(R.drawable.border_sky_blue_fill_16)
+            } else {
+                binding.root.setBackgroundResource(R.drawable.border_transparent_fill)
+            }
         }
-    }
-
-    fun getHeaderLayoutView(recyclerView: RecyclerView): View {
-        return ItemDrawerHeaderBinding.inflate(LayoutInflater.from(recyclerView.context),
-            recyclerView,
-            false).root
     }
 }

--- a/app/src/main/java/com/ariari/mowoori/ui/home/adapter/DrawerAdapter.kt
+++ b/app/src/main/java/com/ariari/mowoori/ui/home/adapter/DrawerAdapter.kt
@@ -22,13 +22,7 @@ class DrawerAdapter(private val listener: OnItemClickListener) :
         private const val GROUP = 1
     }
 
-    private val groups = listOf(
-        GroupInfo("정직한 코박쥐들"),
-        GroupInfo("못생긴 원숭이들"),
-        GroupInfo("고약한 거북이들"),
-        GroupInfo("귀여운 개구리들"),
-        GroupInfo("행복한 캥거루들")
-    )
+    var groups = listOf<GroupInfo>()
 
     override fun getItemViewType(position: Int): Int {
         return when (position) {

--- a/app/src/main/java/com/ariari/mowoori/ui/home/entity/Group.kt
+++ b/app/src/main/java/com/ariari/mowoori/ui/home/entity/Group.kt
@@ -9,4 +9,5 @@ data class GroupInfo(
     val groupName: String = "",
     val userList: List<String> = emptyList(),
     val missionList: List<String> = emptyList(),
+    var selected: Boolean = false,
 )

--- a/app/src/main/java/com/ariari/mowoori/ui/register/entity/User.kt
+++ b/app/src/main/java/com/ariari/mowoori/ui/register/entity/User.kt
@@ -6,6 +6,6 @@ data class User(
 )
 
 data class UserInfo(
-    val nickname: String,
-    val groupList: List<String> = emptyList()
+    val nickName: String,
+    val groupList: List<String> = emptyList(),
 )

--- a/app/src/main/res/drawable/border_transparent_fill.xml
+++ b/app/src/main/res/drawable/border_transparent_fill.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="@color/transparent" />
+</shape>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -8,6 +8,7 @@
     <color name="gray_BFC0C2">#BFC0C2</color>
     <color name="gray_545454">#545454</color>
     <color name="red_FF0000">#FF0000</color>
+    <color name="transparent">#00FFFFFF</color>
     <color name="purple_200">#FFBB86FC</color>
     <color name="purple_500">#FF6200EE</color>
     <color name="purple_700">#FF3700B3</color>

--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,7 @@ buildscript {
         hiltCompilerVersion = "1.0.0"
         coroutineVersion = '1.5.0'
         coroutinePlayServices = '1.1.1'
+        gsonVersion = '2.8.9'
     }
     repositories {
         google()


### PR DESCRIPTION
# ❗️ 이슈 트래킹
- #10 

# 💡 작업목록
- 임시로 저장해둔 유저 정보를 가져와서 유저가 가지고 있는 그룹 리스트를 그룹 목록에 띄우기
- 선택된 그룹에 대해 background 처리

# ❓ 고민과 해결
- 그룹 목록 리스트 중 선택된 아이템에 background 를 설정하고, 선택이 취소되었을 때 background 를 다시 원래 상태로 되돌리는 방법을 고민했는데, 일단 선택이 취소된 경우 transparent 로 설정해주었지만, 더 좋은 방법이 있을 듯 하다.

