### PR TITLE
[9-1] 새로운 그룹 생성

### DIFF
--- a/app/src/main/java/com/ariari/mowoori/data/repository/GroupRepository.kt
+++ b/app/src/main/java/com/ariari/mowoori/data/repository/GroupRepository.kt
@@ -1,0 +1,18 @@
+package com.ariari.mowoori.data.repository
+
+import com.ariari.mowoori.ui.home.entity.GroupInfo
+import com.ariari.mowoori.ui.register.entity.User
+import com.ariari.mowoori.ui.register.entity.UserInfo
+
+
+interface GroupRepository {
+    suspend fun getGroupInfo(groupId: String): Result<GroupInfo>
+
+    fun putGroupInfo(groupInfo: GroupInfo, user: User): Result<String>
+
+    suspend fun addUserToGroup(groupId: String, user: User): Result<String>
+
+    suspend fun getUser(): Result<User>
+
+    suspend fun isExistGroupId(groupId: String): Boolean
+}

--- a/app/src/main/java/com/ariari/mowoori/data/repository/GroupRepositoryImpl.kt
+++ b/app/src/main/java/com/ariari/mowoori/data/repository/GroupRepositoryImpl.kt
@@ -1,0 +1,70 @@
+package com.ariari.mowoori.data.repository
+
+import com.ariari.mowoori.ui.home.entity.GroupInfo
+import com.ariari.mowoori.ui.register.entity.User
+import com.ariari.mowoori.ui.register.entity.UserInfo
+import com.google.firebase.auth.FirebaseAuth
+import com.google.firebase.database.DatabaseReference
+import kotlinx.coroutines.tasks.await
+import javax.inject.Inject
+
+
+class GroupRepositoryImpl @Inject constructor(
+    private val databaseReference: DatabaseReference,
+    private val firebaseAuth: FirebaseAuth
+) : GroupRepository {
+    override suspend fun getGroupInfo(groupId: String): Result<GroupInfo> = kotlin.runCatching {
+        val snapshot = databaseReference.child("groups/$groupId").get().await()
+        snapshot.getValue(GroupInfo::class.java)
+            ?: throw NullPointerException("getGroupInfo is null")
+    }
+
+    override fun putGroupInfo(groupInfo: GroupInfo, user: User): Result<String> =
+        kotlin.runCatching {
+            val newId = databaseReference.child("groups").push().key
+            newId?.let {
+                val tmpGroupList = user.userInfo.groupList
+                    .toMutableList().apply {
+                        add(newId)
+                    }
+                val newUserInfo = user.userInfo.copy(groupList = tmpGroupList, currentGroupId = newId)
+                val childUpdates = hashMapOf(
+                    "/groups/$newId" to groupInfo,
+                    "/users/${user.userId}" to newUserInfo
+                )
+                databaseReference.updateChildren(childUpdates)
+                newId
+            } ?: throw NullPointerException("Couldn't get push key for posts")
+        }
+
+    override suspend fun addUserToGroup(groupId: String, user: User): Result<String> =
+        kotlin.runCatching {
+            val snapshot = databaseReference.child("groups/$groupId").get().await()
+            val tmpGroup = snapshot.getValue(GroupInfo::class.java)
+                ?: throw NullPointerException("group is Null")
+            val tmpUserList = tmpGroup.userList.toMutableList().apply { add(user.userId) }
+            val newGroupInfo = tmpGroup.copy(userList = tmpUserList)
+
+            val tmpGroupList = user.userInfo.groupList.toMutableList().apply { add(groupId) }
+            val newUserInfo = user.userInfo.copy(groupList = tmpGroupList, currentGroupId = groupId)
+            val childUpdates = hashMapOf(
+                "/groups/$groupId" to newGroupInfo,
+                "/users/${user.userId}" to newUserInfo
+            )
+            databaseReference.updateChildren(childUpdates)
+            groupId
+        }
+
+    override suspend fun getUser(): Result<User> = kotlin.runCatching {
+        val uid = firebaseAuth.currentUser?.uid ?: throw NullPointerException("uid is null")
+        val snapshot = databaseReference.child("users/$uid").get().await()
+        val userInfo = snapshot.getValue(UserInfo::class.java)
+            ?: throw NullPointerException("userInfo is null")
+        User(uid, userInfo)
+    }
+
+    override suspend fun isExistGroupId(groupId: String): Boolean {
+        val snapshot = databaseReference.child("groups/$groupId").get().await()
+        return snapshot.exists()
+    }
+}

--- a/app/src/main/java/com/ariari/mowoori/data/repository/HomeRepository.kt
+++ b/app/src/main/java/com/ariari/mowoori/data/repository/HomeRepository.kt
@@ -1,0 +1,10 @@
+package com.ariari.mowoori.data.repository
+
+import com.ariari.mowoori.ui.register.entity.UserInfo
+
+
+interface HomeRepository {
+    fun getUserUid(): String?
+
+    suspend fun getUserInfo(uid: String): Result<UserInfo>
+}

--- a/app/src/main/java/com/ariari/mowoori/data/repository/HomeRepositoryImpl.kt
+++ b/app/src/main/java/com/ariari/mowoori/data/repository/HomeRepositoryImpl.kt
@@ -1,0 +1,29 @@
+package com.ariari.mowoori.data.repository
+
+import android.net.Uri
+import com.ariari.mowoori.ui.register.entity.UserInfo
+import com.google.firebase.auth.FirebaseAuth
+import com.google.firebase.database.DatabaseReference
+import com.google.firebase.database.GenericTypeIndicator
+import com.google.firebase.storage.StorageReference
+import kotlinx.coroutines.tasks.await
+import java.lang.Exception
+import java.lang.NullPointerException
+import javax.inject.Inject
+
+class HomeRepositoryImpl @Inject constructor(
+    private val firebaseReference: DatabaseReference,
+    private val firebaseAuth: FirebaseAuth
+) : HomeRepository {
+    override fun getUserUid(): String? {
+        return firebaseAuth.currentUser?.uid
+    }
+
+    override suspend fun getUserInfo(uid: String): Result<UserInfo> = kotlin.runCatching {
+        val snapshot = firebaseReference.child("users/$uid").get().await()
+        val userInfo = snapshot.getValue(UserInfo::class.java)
+        userInfo ?: throw NullPointerException("userInfo is Null")
+    }
+
+
+}

--- a/app/src/main/java/com/ariari/mowoori/di/RepositoryModule.kt
+++ b/app/src/main/java/com/ariari/mowoori/di/RepositoryModule.kt
@@ -1,5 +1,7 @@
 package com.ariari.mowoori.di
 
+import com.ariari.mowoori.data.repository.HomeRepository
+import com.ariari.mowoori.data.repository.HomeRepositoryImpl
 import com.ariari.mowoori.data.repository.IntroRepository
 import com.ariari.mowoori.data.repository.IntroRepositoryImpl
 import com.ariari.mowoori.data.repository.MissionsRepository
@@ -32,4 +34,12 @@ object RepositoryModule {
         firebaseAuth: FirebaseAuth
     ): MissionsRepository =
         MissionsRepositoryImpl(databaseReference, firebaseAuth)
+        IntroRepositoryImpl(databaseReference, storageReference,firebaseAuth)
+
+    @Provides
+    @Singleton
+    fun providesMainRepository(
+        databaseReference: DatabaseReference,
+        firebaseAuth: FirebaseAuth
+    ): HomeRepository = HomeRepositoryImpl(databaseReference,firebaseAuth)
 }

--- a/app/src/main/java/com/ariari/mowoori/di/RepositoryModule.kt
+++ b/app/src/main/java/com/ariari/mowoori/di/RepositoryModule.kt
@@ -1,5 +1,7 @@
 package com.ariari.mowoori.di
 
+import com.ariari.mowoori.data.repository.GroupRepository
+import com.ariari.mowoori.data.repository.GroupRepositoryImpl
 import com.ariari.mowoori.data.repository.HomeRepository
 import com.ariari.mowoori.data.repository.HomeRepositoryImpl
 import com.ariari.mowoori.data.repository.IntroRepository
@@ -34,7 +36,6 @@ object RepositoryModule {
         firebaseAuth: FirebaseAuth
     ): MissionsRepository =
         MissionsRepositoryImpl(databaseReference, firebaseAuth)
-        IntroRepositoryImpl(databaseReference, storageReference,firebaseAuth)
 
     @Provides
     @Singleton
@@ -42,4 +43,12 @@ object RepositoryModule {
         databaseReference: DatabaseReference,
         firebaseAuth: FirebaseAuth
     ): HomeRepository = HomeRepositoryImpl(databaseReference,firebaseAuth)
+
+    @Provides
+    @Singleton
+    fun providesGroupRepository(
+        databaseReference: DatabaseReference,
+        firebaseAuth: FirebaseAuth
+    ): GroupRepository = GroupRepositoryImpl(databaseReference,firebaseAuth)
+
 }

--- a/app/src/main/java/com/ariari/mowoori/ui/group/GroupFragment.kt
+++ b/app/src/main/java/com/ariari/mowoori/ui/group/GroupFragment.kt
@@ -6,8 +6,8 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import androidx.core.view.isInvisible
 import androidx.core.view.isVisible
+import androidx.core.widget.doOnTextChanged
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
@@ -15,7 +15,10 @@ import androidx.navigation.fragment.navArgs
 import com.ariari.mowoori.R
 import com.ariari.mowoori.databinding.FragmentGroupBinding
 import com.ariari.mowoori.ui.group.entity.GroupMode
+import com.ariari.mowoori.util.toastMessage
+import dagger.hilt.android.AndroidEntryPoint
 
+@AndroidEntryPoint
 class GroupFragment : Fragment() {
 
     private var _binding: FragmentGroupBinding? = null
@@ -39,16 +42,20 @@ class GroupFragment : Fragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+        binding.lifecycleOwner = viewLifecycleOwner
+        binding.viewModel = viewModel
         setAnimationTarget()
+        setValidationObserver()
+        setAddGroupCompleteObserver()
+        setOnCompleteClickListener()
+        setGroupNameChangeListener()
         when (args.groupMode) {
             GroupMode.INVITE -> {
                 setTitle(R.string.group_invite_title)
             }
             GroupMode.NEW -> {
                 setTitle(R.string.group_name_title)
-                setGroupName()
-                setGroupNameValidation()
-                setValidationObserver()
+                viewModel.setGroupName()
             }
         }
     }
@@ -61,26 +68,38 @@ class GroupFragment : Fragment() {
         binding.tvGroupTitle.setText(resId)
     }
 
-    private fun setGroupName() {
-        // TODO: 그룹 이름 생성 (형용사 + 명사)
-    }
-
-    private fun setGroupNameValidation() {
-        binding.btnGroupComplete.setOnClickListener {
-            viewModel.checkGroupNameValidation(binding.etGroup.text.toString())
-        }
-    }
-
     private fun setValidationObserver() {
-        viewModel.isValid.observe(viewLifecycleOwner, { isValid ->
-            if (isValid) {
-                viewModel.addNewGroup()
-                binding.tvGroupInvalid.isInvisible = true
-                this.findNavController().navigate(R.id.action_groupNameFragment_to_homeFragment)
+        viewModel.inValidEvent.observe(viewLifecycleOwner, {
+            binding.tvGroupInvalid.isVisible = true
+            objectAnimator.start()
+        })
+    }
+
+    private fun setAddGroupCompleteObserver() {
+        viewModel.addGroupCompleteEvent.observe(viewLifecycleOwner, {
+            val newGroupId = it.peekContent()
+            if (newGroupId.isNotEmpty()) {
+                findNavController().navigate(R.id.action_groupNameFragment_to_homeFragment)
             } else {
-                binding.tvGroupInvalid.isVisible = true
-                objectAnimator.start()
+                toastMessage("그룹 생성에 실패하였습니다.")
             }
         })
+    }
+
+    private fun setGroupNameChangeListener() {
+        binding.etGroup.doOnTextChanged { _, _, _, _ -> binding.tvGroupInvalid.isVisible = false }
+    }
+
+    private fun setOnCompleteClickListener() {
+        binding.btnGroupComplete.setOnClickListener {
+            when (args.groupMode) {
+                GroupMode.INVITE -> {
+                    viewModel.joinGroup()
+                }
+                GroupMode.NEW -> {
+                    viewModel.addNewGroup()
+                }
+            }
+        }
     }
 }

--- a/app/src/main/java/com/ariari/mowoori/ui/group/GroupViewModel.kt
+++ b/app/src/main/java/com/ariari/mowoori/ui/group/GroupViewModel.kt
@@ -2,35 +2,69 @@ package com.ariari.mowoori.ui.group
 
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
-import androidx.lifecycle.Transformations
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.ariari.mowoori.data.repository.GroupRepository
+import com.ariari.mowoori.data.repository.IntroRepository
 import com.ariari.mowoori.ui.home.entity.GroupInfo
-import com.google.firebase.database.FirebaseDatabase
+import com.ariari.mowoori.util.Event
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import javax.inject.Inject
 
-class GroupViewModel : ViewModel() {
-    // TODO: Hilt 인스턴스 주입
-    private val firebaseDatabase = FirebaseDatabase.getInstance()
-    private val databaseReference = firebaseDatabase.reference
+@HiltViewModel
+class GroupViewModel @Inject constructor(
+    private val groupRepository: GroupRepository,
+    private val introRepository: IntroRepository
+) : ViewModel() {
 
-    private val _groupName = MutableLiveData<String>()
-    private val _isValid = Transformations.map(_groupName) { groupName ->
-        groupName.length in 1..8
+    val groupName = MutableLiveData<String>("")
+
+    private val _addGroupCompleteEvent = MutableLiveData<Event<String>>()
+    val addGroupCompleteEvent: LiveData<Event<String>> = _addGroupCompleteEvent
+
+    private val _inValidEvent = MutableLiveData<Event<Unit>>()
+    val inValidEvent: LiveData<Event<Unit>> = _inValidEvent
+
+    fun setGroupName() {
+        viewModelScope.launch(Dispatchers.IO) {
+            val randomName = introRepository.getRandomNickName()
+            groupName.postValue(randomName + "들")
+        }
     }
-    val isValid: LiveData<Boolean> = _isValid
 
-    fun checkGroupNameValidation(name: String) {
-        _groupName.value = name
+    fun joinGroup() {
+        viewModelScope.launch(Dispatchers.IO) {
+            val name = groupName.value ?: return@launch
+            val exist = groupRepository.isExistGroupId(name)
+            if (!exist) {
+                _inValidEvent.postValue(Event(Unit))
+            } else {
+                val user = groupRepository.getUser().getOrNull() ?: run {
+                    _addGroupCompleteEvent.postValue(Event(""))
+                    return@launch
+                }
+                groupRepository.addUserToGroup(name, user).onSuccess { newGroupId ->
+                    _addGroupCompleteEvent.postValue(Event(newGroupId))
+                }.onFailure {
+                    _addGroupCompleteEvent.postValue(Event(""))
+                }
+            }
+        }
     }
 
-    // TODO: 레포지토리에 실행되어야할 코드
     fun addNewGroup() {
-        // TODO: 유저 아이디 가져오기
-
-        val name = _groupName.value ?: return
-        val groupInfo = GroupInfo(name)
-        val groupId = databaseReference.child("groups").push().key ?: return
-        databaseReference.child("groups").child(groupId).setValue(groupInfo)
-
-        // TODO: 가져온 유저의 그룹 리스트에 생성한 그룹 추가
+        viewModelScope.launch(Dispatchers.IO) {
+            groupRepository.getUser().onSuccess {
+                val name = groupName.value ?: return@launch
+                val groupInfo = GroupInfo(name, listOf(it.userId))
+                groupRepository.putGroupInfo(groupInfo, it).onSuccess { newGroupId ->
+                    _addGroupCompleteEvent.postValue(Event(newGroupId))
+                }.onFailure {
+                    _addGroupCompleteEvent.postValue(Event(""))
+                }
+            }
+        }
     }
 }

--- a/app/src/main/java/com/ariari/mowoori/ui/home/HomeFragment.kt
+++ b/app/src/main/java/com/ariari/mowoori/ui/home/HomeFragment.kt
@@ -14,6 +14,7 @@ import android.view.animation.AccelerateInterpolator
 import android.widget.ImageView
 import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.activityViewModels
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.findNavController
@@ -45,9 +46,8 @@ class HomeFragment : Fragment() {
     private lateinit var snowFaceDownAnim: Animator
     private lateinit var snowFaceUpAnim: Animator
 
-    override fun onAttach(context: Context) {
-        super.onAttach(context)
-        // onAttach 콜백함수는 최초 한번만 실행된다.
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
         setUserInfo()
     }
 
@@ -77,7 +77,6 @@ class HomeFragment : Fragment() {
     }
 
     private fun setUserInfo() {
-        // TODO: 유저아이디는 로컬에서 가져오기 (현재는 더미 데이터 사용)
         viewModel.setUserInfo()
     }
 

--- a/app/src/main/java/com/ariari/mowoori/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/com/ariari/mowoori/ui/home/HomeViewModel.kt
@@ -62,8 +62,7 @@ class HomeViewModel @Inject constructor(
         val tempGroupList = mutableListOf<GroupInfo>()
         userInfo.groupList.forEachIndexed { index, groupId ->
             databaseReference.child("groups").child(groupId).get().addOnSuccessListener {
-                val groupInfoJson = it.value ?: return@addOnSuccessListener
-                val groupInfo = gson.fromJson(groupInfoJson.toString(), GroupInfo::class.java)
+                val groupInfo = it.getValue(GroupInfo::class.java) ?: return@addOnSuccessListener
                 if (index == 0) {
                     groupInfo.selected = true
                     _currentGroupInfo.value = groupInfo

--- a/app/src/main/java/com/ariari/mowoori/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/com/ariari/mowoori/ui/home/HomeViewModel.kt
@@ -4,13 +4,24 @@ import android.animation.Animator
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.ariari.mowoori.data.repository.HomeRepository
+import com.ariari.mowoori.data.repository.IntroRepository
 import com.ariari.mowoori.ui.home.entity.GroupInfo
 import com.ariari.mowoori.ui.register.entity.UserInfo
 import com.ariari.mowoori.util.Event
+import com.ariari.mowoori.util.TimberUtil
 import com.google.firebase.database.FirebaseDatabase
 import com.google.gson.Gson
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import javax.inject.Inject
 
-class HomeViewModel : ViewModel() {
+@HiltViewModel
+class HomeViewModel @Inject constructor(
+    private val homeRepository: HomeRepository
+) : ViewModel() {
     // TODO: Hilt 인스턴스 주입
     private val firebaseDatabase = FirebaseDatabase.getInstance()
     private val databaseReference = firebaseDatabase.reference
@@ -34,14 +45,16 @@ class HomeViewModel : ViewModel() {
     private val snowAnimList: MutableList<Animator> = mutableListOf()
 
     fun setUserInfo() {
-        // TODO: 레포지토리에서 실행되는 코드
-        val tempUserId = "kldaji"
-        databaseReference.child("users").child(tempUserId).get().addOnSuccessListener {
-            val userInfoJson = it.value ?: return@addOnSuccessListener
-            val userInfo = gson.fromJson(userInfoJson.toString(), UserInfo::class.java)
-            _userInfo.value = Event(userInfo)
-        }.addOnFailureListener {
-            // TODO: 실패처리
+        val uid = homeRepository.getUserUid()
+        uid?.let {
+            viewModelScope.launch(Dispatchers.IO) {
+                val result = homeRepository.getUserInfo(it)
+                result.onSuccess { userInfo ->
+                    _userInfo.postValue(Event(userInfo))
+                }.onFailure {
+                    TimberUtil.timber("setUserInfo*()", "$it")// TODO: 실패처리
+                }
+            }
         }
     }
 

--- a/app/src/main/java/com/ariari/mowoori/ui/register/entity/User.kt
+++ b/app/src/main/java/com/ariari/mowoori/ui/register/entity/User.kt
@@ -6,7 +6,7 @@ data class User(
 )
 
 data class UserInfo(
-    val nickname: String,
-    val profileImage: String,
+    val nickname: String = "",
+    val profileImage: String = "",
     val groupList: List<String> = emptyList(),
 )

--- a/app/src/main/java/com/ariari/mowoori/ui/register/entity/User.kt
+++ b/app/src/main/java/com/ariari/mowoori/ui/register/entity/User.kt
@@ -9,4 +9,5 @@ data class UserInfo(
     val nickname: String = "",
     val profileImage: String = "",
     val groupList: List<String> = emptyList(),
+    val currentGroupId: String = ""
 )

--- a/app/src/main/java/com/ariari/mowoori/util/ToastMessageUtil.kt
+++ b/app/src/main/java/com/ariari/mowoori/util/ToastMessageUtil.kt
@@ -2,7 +2,12 @@ package com.ariari.mowoori.util
 
 import android.content.Context
 import android.widget.Toast
+import androidx.fragment.app.Fragment
 
 fun Context.toastMessage(msg: String) {
     Toast.makeText(this, msg, Toast.LENGTH_SHORT).show()
+}
+
+fun Fragment.toastMessage(msg: String){
+    this.requireContext().toastMessage(msg)
 }

--- a/app/src/main/res/layout/activity_register.xml
+++ b/app/src/main/res/layout/activity_register.xml
@@ -55,7 +55,7 @@
             android:gravity="center"
             android:inputType="text"
             android:lines="1"
-            android:maxLength="10"
+            android:maxLength="11"
             android:text="@={viewModel.profileText}"
             android:textColor="@color/black"
             android:textSize="36sp"

--- a/app/src/main/res/layout/fragment_group.xml
+++ b/app/src/main/res/layout/fragment_group.xml
@@ -1,9 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <layout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto">
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
 
     <data>
 
+        <variable
+            name="viewModel"
+            type="com.ariari.mowoori.ui.group.GroupViewModel" />
     </data>
 
     <androidx.constraintlayout.motion.widget.MotionLayout
@@ -30,18 +34,19 @@
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_margin="16dp"
-            android:hint="@string/group_name_hint"
             android:importantForAutofill="no"
+            android:lines="1"
             android:inputType="text"
-            android:text="@string/group_name"
+            android:text="@={viewModel.groupName}"
             android:textAlignment="center"
             android:textColor="@color/black"
-            android:textSize="36sp"
+            android:textSize="32sp"
             android:textStyle="bold"
             app:layout_constraintBottom_toTopOf="@id/btn_group_complete"
             app:layout_constraintEnd_toEndOf="@id/tv_group_title"
             app:layout_constraintStart_toStartOf="@id/tv_group_title"
-            app:layout_constraintTop_toBottomOf="@id/tv_group_title" />
+            app:layout_constraintTop_toBottomOf="@id/tv_group_title"
+            tools:ignore="LabelFor" />
 
         <TextView
             android:id="@+id/tv_group_invalid"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -11,7 +11,7 @@
 
     <!-- Register -->
     <string name="register_please_enter_nickname">닉네임을\n입력해주세요</string>
-    <string name="register_nickname_hint">(1자 이상 10자 이하)</string>
+    <string name="register_nickname_hint">(1자 이상 11자 이하)</string>
     <string name="register_nickname_error_msg">닉네임을 확인해주세요</string>
     <string name="register_fail_msg">회원가입에 실패했습니다.</string>
     <string name="desc_profile_image">프로필 이미지</string>


### PR DESCRIPTION
# ❗️ 이슈 트래킹
- #17 

# 💡 작업목록
- groupRepository 추가
- 그룹추가 기능 구현 (새로운그룹추가,기존그룹 참여)
- UserInfo 클래스에 currentGroupId 파라미터 추가

# ❓ 고민과 해결
- 유저의 현재 활성화된 그룹을 내부 db를 이용하여 저장하려 했으나 외부db(firebase or Server)에도 전달할 필요가 있다고 생각되어 UserInfo 클래스에 현재 그룹id를 가지는 파라미터를 추가하여 적용 했습니다.
- 그룹 추가를 하게된다면 Firebase의 'groups' 와 'users' 모두 업데이트 해야했습니다. firebase document 를 참고하여 `firebaseRef.updateChildren()` 함수를 이용했습니다.

