### PR TITLE
[13-1] shared element transition 적용

### DIFF
--- a/app/src/main/java/com/ariari/mowoori/ui/stamp/StampsFragment.kt
+++ b/app/src/main/java/com/ariari/mowoori/ui/stamp/StampsFragment.kt
@@ -17,6 +17,7 @@ import com.ariari.mowoori.ui.missions.entity.MissionInfo
 import com.ariari.mowoori.ui.stamp.adapter.StampsAdapter
 import com.ariari.mowoori.ui.stamp.entity.StampInfo
 import com.ariari.mowoori.util.EventObserver
+import com.ariari.mowoori.widget.ProgressDialogManager
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
@@ -60,6 +61,7 @@ class StampsFragment : BaseFragment<FragmentStampsBinding>(R.layout.fragment_sta
     }
 
     private fun setStampList() {
+        viewModel.setLoadingEvent(true)
         viewModel.setStampList(missionInfo.stampList)
     }
 
@@ -92,10 +94,18 @@ class StampsFragment : BaseFragment<FragmentStampsBinding>(R.layout.fragment_sta
     }
 
     private fun setObserver() {
+        setLoadingObserver()
         setBackBtnObserver()
         setSpanCountObserver()
         setStampListObserver()
         setSelectedStampInfoObserver()
+    }
+
+    private fun setLoadingObserver() {
+        viewModel.loadingEvent.observe(viewLifecycleOwner, EventObserver {
+            if (it) ProgressDialogManager.instance.show(requireContext())
+            else ProgressDialogManager.instance.clear()
+        })
     }
 
     private fun setBackBtnObserver() {
@@ -131,6 +141,7 @@ class StampsFragment : BaseFragment<FragmentStampsBinding>(R.layout.fragment_sta
         viewModel.stampList.observe(viewLifecycleOwner, { stampList ->
             adapter.submitList(stampList)
             viewModel.fillEmptyStamps(missionInfo.totalStamp - stampList.size)
+            viewModel.setLoadingEvent(false)
         })
     }
 

--- a/app/src/main/java/com/ariari/mowoori/ui/stamp/StampsFragment.kt
+++ b/app/src/main/java/com/ariari/mowoori/ui/stamp/StampsFragment.kt
@@ -31,7 +31,6 @@ class StampsFragment : BaseFragment<FragmentStampsBinding>(R.layout.fragment_sta
         binding.viewModel = viewModel
         setMissionInfo()
         setMissionName()
-        setAllEmptyStamps()
         setStampList()
         setAdapter()
         setSpanCount()
@@ -55,10 +54,6 @@ class StampsFragment : BaseFragment<FragmentStampsBinding>(R.layout.fragment_sta
         viewModel.setMissionName(missionInfo.missionName)
     }
 
-    private fun setAllEmptyStamps() {
-        viewModel.setAllEmptyStamps(missionInfo.totalStamp)
-    }
-
     private fun setStampList() {
         viewModel.setStampList(missionInfo.stampList)
     }
@@ -66,6 +61,7 @@ class StampsFragment : BaseFragment<FragmentStampsBinding>(R.layout.fragment_sta
     private fun setStampListObserver() {
         viewModel.stampList.observe(viewLifecycleOwner, { stampList ->
             adapter.submitList(stampList)
+            viewModel.fillEmptyStamps(missionInfo.totalStamp - stampList.size)
         })
     }
 
@@ -95,8 +91,9 @@ class StampsFragment : BaseFragment<FragmentStampsBinding>(R.layout.fragment_sta
 
     private fun setCompleteClick() {
         binding.btnStampsComplete.setOnClickListener {
-            it.findNavController().navigate(StampsFragmentDirections.actionStampsFragmentToStampDetailFragment(
-                StampInfo(), missionInfo.missionName))
+            it.findNavController()
+                .navigate(StampsFragmentDirections.actionStampsFragmentToStampDetailFragment(
+                    StampInfo(), missionInfo.missionName))
         }
     }
 

--- a/app/src/main/java/com/ariari/mowoori/ui/stamp/StampsViewModel.kt
+++ b/app/src/main/java/com/ariari/mowoori/ui/stamp/StampsViewModel.kt
@@ -56,7 +56,6 @@ class StampsViewModel @Inject constructor(private val stampsRepository: StampsRe
     }
 
     fun setStampList(stampIdList: List<String>) {
-        val currentStampList = _stampList.value ?: return
         // postValue 이슈 방지를 위해 for 문 밖에서 스코프 설정
         viewModelScope.launch(Dispatchers.IO) {
             val tempStampList = mutableListOf<Stamp>()
@@ -69,10 +68,21 @@ class StampsViewModel @Inject constructor(private val stampsRepository: StampsRe
                         println("${it.message}")
                     }
             }
-            // 리스트의 깊은 복사를 위한 addAll 처리
-            tempStampList.addAll(currentStampList.subList(stampIdList.size, currentStampList.size))
             _stampList.postValue(tempStampList)
         }
+    }
+
+    fun fillEmptyStamps(count: Int) {
+        val currentStampList = _stampList.value ?: return
+        if (count == 0) return
+
+        val tempEmptyStampList = mutableListOf<Stamp>()
+        // 리스트의 깊은 복사를 위한 addAll 처리
+        tempEmptyStampList.addAll(currentStampList)
+        repeat(count) {
+            tempEmptyStampList.add(Stamp(stampInfo = StampInfo()))
+        }
+        _stampList.value = tempEmptyStampList
     }
 
     fun setSelectedStampInfo(position: Int, currentStamp: Int) {

--- a/app/src/main/java/com/ariari/mowoori/ui/stamp/StampsViewModel.kt
+++ b/app/src/main/java/com/ariari/mowoori/ui/stamp/StampsViewModel.kt
@@ -17,6 +17,9 @@ import javax.inject.Inject
 class StampsViewModel @Inject constructor(private val stampsRepository: StampsRepository) :
     ViewModel() {
 
+    private val _loadingEvent = MutableLiveData<Event<Boolean>>()
+    val loadingEvent: LiveData<Event<Boolean>> get() = _loadingEvent
+
     private val _spanCount = MutableLiveData<Event<Int>>()
     val spanCount: LiveData<Event<Int>> get() = _spanCount
 
@@ -34,6 +37,10 @@ class StampsViewModel @Inject constructor(private val stampsRepository: StampsRe
 
     private val _isMyMission = MutableLiveData<Event<Boolean>>()
     val isMyMission: LiveData<Event<Boolean>> get() = _isMyMission
+
+    fun setLoadingEvent(flag: Boolean) {
+        _loadingEvent.value = Event(flag)
+    }
 
     fun setSpanCount(result: Float) {
         _spanCount.value = Event(result.toInt())

--- a/app/src/main/java/com/ariari/mowoori/ui/stamp/adapter/StampsAdapter.kt
+++ b/app/src/main/java/com/ariari/mowoori/ui/stamp/adapter/StampsAdapter.kt
@@ -2,6 +2,7 @@ package com.ariari.mowoori.ui.stamp.adapter
 
 import android.view.LayoutInflater
 import android.view.ViewGroup
+import androidx.core.view.isInvisible
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
@@ -49,8 +50,10 @@ class StampsAdapter(private val listener: OnItemClickListener) :
         }
 
         fun bind(stampInfo: StampInfo) {
+            binding.tvItemStampsIndex.text = (adapterPosition + 1).toString()
             if (stampInfo.pictureUrl != "") {
                 binding.ivItemStamps.setImageResource(R.drawable.ic_launcher_background)
+                binding.tvItemStampsIndex.isInvisible = true
             }
         }
     }

--- a/app/src/main/java/com/ariari/mowoori/ui/stamp/adapter/StampsAdapter.kt
+++ b/app/src/main/java/com/ariari/mowoori/ui/stamp/adapter/StampsAdapter.kt
@@ -2,6 +2,8 @@ package com.ariari.mowoori.ui.stamp.adapter
 
 import android.view.LayoutInflater
 import android.view.ViewGroup
+import android.widget.ImageView
+import androidx.core.view.ViewCompat
 import androidx.core.view.isInvisible
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
@@ -27,7 +29,7 @@ class StampsAdapter(private val listener: OnItemClickListener) :
     }
 
     interface OnItemClickListener {
-        fun itemClick(position: Int)
+        fun itemClick(position: Int, imageView: ImageView)
     }
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): StampViewHolder {
@@ -45,11 +47,12 @@ class StampsAdapter(private val listener: OnItemClickListener) :
 
         init {
             binding.root.setOnClickListener {
-                listener.itemClick(adapterPosition)
+                listener.itemClick(adapterPosition, binding.ivItemStamps)
             }
         }
 
         fun bind(stampInfo: StampInfo) {
+            ViewCompat.setTransitionName(binding.ivItemStamps, stampInfo.pictureUrl)
             binding.tvItemStampsIndex.text = (adapterPosition + 1).toString()
             if (stampInfo.pictureUrl != "") {
                 binding.ivItemStamps.setImageResource(R.drawable.ic_launcher_background)

--- a/app/src/main/java/com/ariari/mowoori/ui/stamp_detail/StampDetailFragment.kt
+++ b/app/src/main/java/com/ariari/mowoori/ui/stamp_detail/StampDetailFragment.kt
@@ -5,6 +5,7 @@ import android.view.View
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
+import androidx.transition.TransitionInflater
 import com.ariari.mowoori.R
 import com.ariari.mowoori.base.BaseFragment
 import com.ariari.mowoori.databinding.FragmentStampDetailBinding
@@ -18,13 +19,21 @@ class StampDetailFragment :
     private val viewModel: StampDetailViewModel by viewModels()
     private lateinit var stampInfo: StampInfo
 
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        sharedElementEnterTransition =
+            TransitionInflater.from(context).inflateTransition(android.R.transition.move)
+    }
+
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         binding.lifecycleOwner = viewLifecycleOwner
         binding.viewModel = viewModel
         setStampInfo()
         setCloseBtnClickObserver()
-        binding.tvStampDetail.text = safeArgs.stampInfo.comment
+        setDetailTransitionName()
+        setDetailText()
+        setDetailImageView()
     }
 
     private fun setStampInfo() {
@@ -35,5 +44,19 @@ class StampDetailFragment :
         viewModel.closeBtnClick.observe(viewLifecycleOwner, EventObserver {
             this.findNavController().popBackStack()
         })
+    }
+
+    private fun setDetailTransitionName() {
+        binding.ivStampDetail.transitionName = stampInfo.pictureUrl
+    }
+
+    private fun setDetailText() {
+        binding.tvStampDetail.text = safeArgs.stampInfo.comment
+    }
+
+    private fun setDetailImageView() {
+        if (stampInfo.pictureUrl != "") {
+            binding.ivStampDetail.setImageResource(R.drawable.ic_launcher_background)
+        }
     }
 }

--- a/app/src/main/res/layout/fragment_stamp_detail.xml
+++ b/app/src/main/res/layout/fragment_stamp_detail.xml
@@ -34,5 +34,13 @@
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent" />
 
+        <ImageView
+            android:id="@+id/iv_stamp_detail"
+            android:layout_width="200dp"
+            android:layout_height="200dp"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/tv_stamp_detail" />
+
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/app/src/main/res/layout/item_stamps.xml
+++ b/app/src/main/res/layout/item_stamps.xml
@@ -23,10 +23,8 @@
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent" />
 
-        <ImageView
-            android:contentDescription="@string/desc_item_stamps_icon"
-            android:src="@drawable/ic_snow"
-            android:id="@+id/iv_item_stamps_icon"
+        <TextView
+            android:id="@+id/tv_item_stamps_index"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:text="@string/stamps_number"


### PR DESCRIPTION
# ❗️ 이슈 트래킹
- #24 

# 💡 작업목록
- 리사이클러뷰의 아이템 리스트 받아오는 순서 변경 (존재하는 스탬프 받고 -> 나머지 빈 스탬프 채우기)
- 스탬프 이미지뷰에 shared element transition 적용
- 리사이클러뷰 아이템이 그려지는 동안 로딩 이벤트 추가

