### PR TITLE
그룹목록 조회 로직 수정

### DIFF
--- a/app/src/main/java/com/ariari/mowoori/data/repository/HomeRepository.kt
+++ b/app/src/main/java/com/ariari/mowoori/data/repository/HomeRepository.kt
@@ -1,6 +1,6 @@
 package com.ariari.mowoori.data.repository
 
-import com.ariari.mowoori.ui.home.entity.GroupInfo
+import com.ariari.mowoori.ui.home.entity.Group
 import com.ariari.mowoori.ui.register.entity.UserInfo
 
 
@@ -9,5 +9,7 @@ interface HomeRepository {
 
     suspend fun getUserInfo(uid: String): Result<UserInfo>
 
-    suspend fun getGroupInfo(groupId: String): Result<GroupInfo>
+    suspend fun getGroup(groupId: String): Result<Group>
+
+    fun setCurrentGroupId(groupId: String)
 }

--- a/app/src/main/java/com/ariari/mowoori/data/repository/HomeRepositoryImpl.kt
+++ b/app/src/main/java/com/ariari/mowoori/data/repository/HomeRepositoryImpl.kt
@@ -1,5 +1,6 @@
 package com.ariari.mowoori.data.repository
 
+import com.ariari.mowoori.ui.home.entity.Group
 import com.ariari.mowoori.ui.home.entity.GroupInfo
 import com.ariari.mowoori.ui.register.entity.UserInfo
 import com.google.firebase.auth.FirebaseAuth
@@ -22,10 +23,18 @@ class HomeRepositoryImpl @Inject constructor(
         userInfo ?: throw NullPointerException("userInfo is Null")
     }
 
-    override suspend fun getGroupInfo(groupId: String): Result<GroupInfo> = kotlin.runCatching {
+    override suspend fun getGroup(groupId: String): Result<Group> = kotlin.runCatching {
         val snapshot = firebaseReference.child("groups/$groupId").get().await()
         val groupInfo = snapshot.getValue(GroupInfo::class.java)
-        groupInfo ?: throw NullPointerException("groupInfo is Null")
+            ?: throw NullPointerException("groupInfo is Null")
+        Group(groupId, groupInfo)
+    }
+
+    override fun setCurrentGroupId(groupId: String) {
+        val uid = getUserUid()
+        uid?.let { userId ->
+            firebaseReference.child("users/$userId/currentGroupId").setValue(groupId)
+        }
     }
 
 }

--- a/app/src/main/java/com/ariari/mowoori/ui/home/HomeFragment.kt
+++ b/app/src/main/java/com/ariari/mowoori/ui/home/HomeFragment.kt
@@ -89,6 +89,7 @@ class HomeFragment : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         binding.lifecycleOwner = viewLifecycleOwner
+        binding.viewModel = homeViewModel
         setUserInfoObserver()
         setCurrentGroupInfoObserver()
         setGroupInfoListObserver()
@@ -109,7 +110,6 @@ class HomeFragment : Fragment() {
     }
 
     private fun setUserInfo() {
-        // TODO: 유저아이디는 로컬에서 가져오기 (현재는 더미 데이터 사용)
         homeViewModel.setUserInfo()
     }
 
@@ -120,14 +120,14 @@ class HomeFragment : Fragment() {
     }
 
     private fun setCurrentGroupInfoObserver() {
-        homeViewModel.currentGroupInfo.observe(viewLifecycleOwner, { groupInfo ->
-            binding.tbHome.title = groupInfo.groupName
+        homeViewModel.currentGroupInfo.observe(viewLifecycleOwner, { group ->
+            adapter.notifyDataSetChanged()
         })
     }
 
     private fun setGroupInfoListObserver() {
-        homeViewModel.groupInfoList.observe(viewLifecycleOwner, { groupInfoList ->
-            adapter.groups = groupInfoList
+        homeViewModel.groupList.observe(viewLifecycleOwner, { groupList ->
+            adapter.groups = groupList
             adapter.notifyDataSetChanged()
         })
     }
@@ -164,8 +164,8 @@ class HomeFragment : Fragment() {
 
     private fun setDrawerAdapter() {
         adapter = DrawerAdapter(object : DrawerAdapter.OnItemClickListener {
-            override fun itemClick(position: Int) {
-                homeViewModel.setCurrentGroupInfo(position)
+            override fun itemClick(groupId: String) {
+                homeViewModel.setCurrentGroupInfo(groupId)
                 binding.drawerHome.close()
             }
         })

--- a/app/src/main/java/com/ariari/mowoori/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/com/ariari/mowoori/ui/home/HomeViewModel.kt
@@ -3,15 +3,14 @@ package com.ariari.mowoori.ui.home
 import android.animation.Animator
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.Transformations
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.ariari.mowoori.data.repository.HomeRepository
-import com.ariari.mowoori.ui.home.entity.GroupInfo
+import com.ariari.mowoori.ui.home.entity.Group
 import com.ariari.mowoori.ui.register.entity.UserInfo
 import com.ariari.mowoori.util.Event
 import com.ariari.mowoori.util.TimberUtil
-import com.google.firebase.database.FirebaseDatabase
-import com.google.gson.Gson
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
@@ -23,19 +22,16 @@ import javax.inject.Inject
 class HomeViewModel @Inject constructor(
     private val homeRepository: HomeRepository
 ) : ViewModel() {
-    // TODO: Hilt 인스턴스 주입
-    private val firebaseDatabase = FirebaseDatabase.getInstance()
-    private val databaseReference = firebaseDatabase.reference
-    private val gson = Gson()
-
     private val _userInfo = MutableLiveData<Event<UserInfo>>()
     val userInfo: LiveData<Event<UserInfo>> = _userInfo
 
-    private val _currentGroupInfo = MutableLiveData<GroupInfo>()
-    val currentGroupInfo: LiveData<GroupInfo> = _currentGroupInfo
+    private val _currentGroupInfo = MutableLiveData<Group>()
+    val currentGroupInfo: LiveData<Group> = _currentGroupInfo
+    val currentGroupName: LiveData<String> =
+        Transformations.map(currentGroupInfo) { group -> group.groupInfo.groupName }
 
-    private val _groupInfoList = MutableLiveData<List<GroupInfo>>()
-    val groupInfoList: LiveData<List<GroupInfo>> = _groupInfoList
+    private val _groupList = MutableLiveData<List<Group>>()
+    val groupList: LiveData<List<Group>> = _groupList
 
     private var _isSnowing = MutableLiveData<Boolean>()
     val isSnowing: LiveData<Boolean> = _isSnowing
@@ -65,26 +61,28 @@ class HomeViewModel @Inject constructor(
     fun setGroupInfoList(userInfo: UserInfo) {
         viewModelScope.launch(Dispatchers.IO) {
             val deferredList =
-                userInfo.groupList.map { groupId -> async { homeRepository.getGroupInfo(groupId) } }
-            val groupList = deferredList.awaitAll().mapNotNull { it.getOrNull() }
-            _groupInfoList.postValue(groupList)
+                userInfo.groupList.map { groupId -> async { homeRepository.getGroup(groupId) } }
+            val groupList = deferredList.awaitAll().mapNotNull { result ->
+                val group = result.getOrNull()
+                group?.apply {
+                    if (this.groupId == userInfo.currentGroupId) {
+                        this.selected = true
+                        _currentGroupInfo.postValue(this)
+                    }
+                }
+            }
+            _groupList.postValue(groupList)
         }
     }
 
-    fun setCurrentGroupInfo(position: Int) {
-        val tempGroupList = _groupInfoList.value?.mapIndexed { index, groupInfo ->
-            when (index) {
-                // 헤더를 포함한 위치 값이기 떄문에 -1 을 해주어야 한다.
-                position - 1 -> {
-                    groupInfo.selected = true
-                    _currentGroupInfo.value = groupInfo
-                }
-                else -> groupInfo.selected = false
+    fun setCurrentGroupInfo(groupId: String) {
+        _groupList.value?.let { groupList ->
+            groupList.forEach {
+                it.selected = it.groupId == groupId
+                if (it.selected) _currentGroupInfo.postValue(it)
             }
-            groupInfo
         }
-        tempGroupList ?: return
-        _groupInfoList.value = tempGroupList.requireNoNulls()
+        homeRepository.setCurrentGroupId(groupId)
     }
 
     fun setIsFirstCycle(isFirst: Boolean) {

--- a/app/src/main/java/com/ariari/mowoori/ui/home/adapter/DrawerAdapter.kt
+++ b/app/src/main/java/com/ariari/mowoori/ui/home/adapter/DrawerAdapter.kt
@@ -8,13 +8,14 @@ import androidx.recyclerview.widget.RecyclerView
 import com.ariari.mowoori.R
 import com.ariari.mowoori.databinding.ItemDrawerGroupBinding
 import com.ariari.mowoori.databinding.ItemDrawerHeaderBinding
+import com.ariari.mowoori.ui.home.entity.Group
 import com.ariari.mowoori.ui.home.entity.GroupInfo
 
 class DrawerAdapter(private val listener: OnItemClickListener) :
     RecyclerView.Adapter<RecyclerView.ViewHolder>() {
 
     interface OnItemClickListener {
-        fun itemClick(position: Int)
+        fun itemClick(groupId: String)
     }
 
     companion object {
@@ -22,7 +23,7 @@ class DrawerAdapter(private val listener: OnItemClickListener) :
         private const val GROUP = 1
     }
 
-    var groups = listOf<GroupInfo>()
+    var groups = listOf<Group>()
 
     override fun getItemViewType(position: Int): Int {
         return when (position) {
@@ -33,12 +34,20 @@ class DrawerAdapter(private val listener: OnItemClickListener) :
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): RecyclerView.ViewHolder {
         return when (viewType) {
-            HEADER -> HeaderViewHolder(ItemDrawerHeaderBinding.inflate(LayoutInflater.from(parent.context),
-                parent,
-                false))
-            else -> GroupViewHolder(ItemDrawerGroupBinding.inflate(LayoutInflater.from(parent.context),
-                parent,
-                false))
+            HEADER -> HeaderViewHolder(
+                ItemDrawerHeaderBinding.inflate(
+                    LayoutInflater.from(parent.context),
+                    parent,
+                    false
+                )
+            )
+            else -> GroupViewHolder(
+                ItemDrawerGroupBinding.inflate(
+                    LayoutInflater.from(parent.context),
+                    parent,
+                    false
+                )
+            )
         }
     }
 
@@ -65,17 +74,21 @@ class DrawerAdapter(private val listener: OnItemClickListener) :
 
         init {
             binding.root.setOnClickListener {
-                listener.itemClick(adapterPosition)
+                binding.group?.groupId?.let { id ->
+                    listener.itemClick(id)
+                }
             }
         }
 
-        fun bind(groupInfo: GroupInfo) {
-            binding.tvDrawerGroupName.text = groupInfo.groupName
-            if (groupInfo.selected) {
+        fun bind(group: Group) {
+            binding.group = group
+            binding.tvDrawerGroupName.text = group.groupInfo.groupName
+            if (group.selected) {
                 binding.root.setBackgroundResource(R.drawable.border_sky_blue_fill_16)
             } else {
                 binding.root.setBackgroundResource(R.drawable.border_transparent_fill)
             }
+            binding.executePendingBindings()
         }
     }
 }

--- a/app/src/main/java/com/ariari/mowoori/ui/home/entity/Group.kt
+++ b/app/src/main/java/com/ariari/mowoori/ui/home/entity/Group.kt
@@ -3,11 +3,11 @@ package com.ariari.mowoori.ui.home.entity
 data class Group(
     val groupId: String,
     val groupInfo: GroupInfo,
+    var selected: Boolean = false,
 )
 
 data class GroupInfo(
     val groupName: String = "",
     val userList: List<String> = emptyList(),
     val missionList: List<String> = emptyList(),
-    var selected: Boolean = false,
 )

--- a/app/src/main/java/com/ariari/mowoori/ui/register/RegisterViewModel.kt
+++ b/app/src/main/java/com/ariari/mowoori/ui/register/RegisterViewModel.kt
@@ -71,6 +71,6 @@ class RegisterViewModel @Inject constructor(
     }
 
     private fun checkNicknameValid(nickname: String): Boolean {
-        return (nickname.length <= 10 && nickname.isNotEmpty())
+        return (nickname.length <= 11 && nickname.isNotEmpty())
     }
 }

--- a/app/src/main/res/layout/fragment_home.xml
+++ b/app/src/main/res/layout/fragment_home.xml
@@ -5,6 +5,9 @@
 
     <data>
 
+        <variable
+            name="viewModel"
+            type="com.ariari.mowoori.ui.home.HomeViewModel" />
     </data>
 
     <androidx.drawerlayout.widget.DrawerLayout
@@ -122,7 +125,8 @@
                     android:layout_height="?attr/actionBarSize"
                     android:background="@color/sky_blue_F1F5FF"
                     app:menu="@menu/tb_home_menu"
-                    app:navigationIcon="@drawable/ic_hamburger" />
+                    app:navigationIcon="@drawable/ic_hamburger"
+                    app:title="@{viewModel.currentGroupName}" />
 
             </com.google.android.material.appbar.AppBarLayout>
 

--- a/app/src/main/res/layout/fragment_stamp_detail.xml
+++ b/app/src/main/res/layout/fragment_stamp_detail.xml
@@ -13,7 +13,8 @@
 
     <androidx.core.widget.NestedScrollView
         android:layout_width="match_parent"
-        android:layout_height="match_parent">
+        android:layout_height="match_parent"
+        android:overScrollMode="never">
 
         <androidx.constraintlayout.widget.ConstraintLayout
             android:id="@+id/container"

--- a/app/src/main/res/layout/item_drawer_group.xml
+++ b/app/src/main/res/layout/item_drawer_group.xml
@@ -3,6 +3,9 @@
     xmlns:app="http://schemas.android.com/apk/res-auto">
 
     <data>
+        <variable
+            name="group"
+            type="com.ariari.mowoori.ui.home.entity.Group" />
 
     </data>
 


### PR DESCRIPTION
# ❗️ 이슈 트래킹
- #10

# 💡 작업목록
- Repository로 부터 group목록 불러오는 로직 수정
- 그룹 변경시 remote(Firebase)에 반영

# ❓ 고민과 해결
- user정보에서 groupId에 대한 리스트를 가지고 각 groupId 마다 비동기 호출로 그룹정보를 가져오게 됩니다. 이때 응답 대기시간을 줄이기위해  `async` 와 `awaitAll`을 사용했습니다.
- 현재 그룹 리스트의 변경이다 현재 유저가 속한 그룹이 변경되었을때 DrawaerAdapter 의 `notifyDataSetChanged` 를 호출하게 되는데 한유저가 속한 그룹이 많지 않을것 같아 기존 코드 유지했습니다.
