### PR TITLE
[12-1] 미션 생성 후 데이터베이스에 저장 방법 수정

### DIFF
--- a/app/src/main/java/com/ariari/mowoori/data/repository/MissionsRepository.kt
+++ b/app/src/main/java/com/ariari/mowoori/data/repository/MissionsRepository.kt
@@ -1,9 +1,8 @@
 package com.ariari.mowoori.data.repository
 
-import com.ariari.mowoori.ui.home.entity.GroupInfo
 import com.ariari.mowoori.ui.missions.entity.Mission
+import com.ariari.mowoori.ui.missions.entity.MissionInfo
 import com.ariari.mowoori.ui.register.entity.User
-import kotlinx.coroutines.tasks.await
 
 interface MissionsRepository {
     // groups에서 해당 group에 있는 missionList get
@@ -18,7 +17,6 @@ interface MissionsRepository {
     suspend fun isExistGroupId(groupId: String): Boolean
 
     // mission 추가
-    suspend fun postMissionIdList(groupId: String, missionIdList: List<String>)
-    suspend fun postMission(mission: Mission)
+    suspend fun postMission(missionInfo: MissionInfo, groupId:String, missionIdList: List<String>)
     suspend fun getUserName(userId: String): Result<String>
 }

--- a/app/src/main/java/com/ariari/mowoori/data/repository/MissionsRepositoryImpl.kt
+++ b/app/src/main/java/com/ariari/mowoori/data/repository/MissionsRepositoryImpl.kt
@@ -58,14 +58,24 @@ class MissionsRepositoryImpl @Inject constructor(
         return snapshot.exists()
     }
 
-    override suspend fun postMission(mission: Mission) {
-        firebaseReference.child("missions").child(mission.missionId)
-            .setValue(mission.missionInfo).await()
-    }
+    override suspend fun postMission(missionInfo: MissionInfo, groupId:String, missionIdList: List<String>) {
+        val missionId = firebaseReference.child("missions").push().key
+        missionId?.let {
+            val updatedMissionList = missionIdList.toMutableList().apply {
+                    add(missionId)
+                }
 
-    override suspend fun postMissionIdList(groupId: String, missionIdList: List<String>) {
-        firebaseReference.child("groups").child(groupId).child("missionList")
-            .setValue(missionIdList).await()
+            val childUpdates = hashMapOf(
+                "missions/$missionId" to missionInfo,
+                "groups/$groupId/missionList" to updatedMissionList
+            )
+            firebaseReference.updateChildren(childUpdates)
+
+//            firebaseReference.child("missions").child(mission.missionId)
+//                .setValue(mission.missionInfo).await()
+
+            missionId
+        }
     }
 
     override suspend fun getUserName(userId: String): Result<String> = kotlin.runCatching {

--- a/app/src/main/java/com/ariari/mowoori/ui/missions_add/MissionsAddViewModel.kt
+++ b/app/src/main/java/com/ariari/mowoori/ui/missions_add/MissionsAddViewModel.kt
@@ -5,7 +5,6 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.ariari.mowoori.data.repository.MissionsRepository
-import com.ariari.mowoori.ui.missions.entity.Mission
 import com.ariari.mowoori.ui.missions.entity.MissionInfo
 import com.ariari.mowoori.util.Event
 import com.ariari.mowoori.util.LogUtil
@@ -55,17 +54,16 @@ class MissionsAddViewModel @Inject constructor(
     fun postMission(missionName: String) {
         viewModelScope.launch(Dispatchers.IO) {
             missionsRepository.getUser().onSuccess { user ->
-                // missionIdList에 항목 추가
+                val missionInfo = getMissionInfo(user.userId, missionName)
                 var missionIdList =
                     missionsRepository.getMissionIdList(user.userInfo.currentGroupId)
-                val mission = createMission(user.userId, missionName)
 
-                if (missionIdList.isEmpty()) missionIdList = mutableListOf()
-                (missionIdList as MutableList).add(mission.missionId)
-                missionsRepository.postMissionIdList(user.userInfo.currentGroupId, missionIdList)
-
-                // missions에 mission 추가
-                missionsRepository.postMission(mission)
+                // missions에 missionInfo 추가, currentGroup의 missionList에 missionInfo 추가
+                missionsRepository.postMission(
+                    missionInfo,
+                    user.userInfo.currentGroupId,
+                    missionIdList
+                )
 
                 // 화면 종료 Event 실행
                 _isMissionPosted.postValue(Event(Unit))
@@ -75,16 +73,13 @@ class MissionsAddViewModel @Inject constructor(
         }
     }
 
-    private fun createMission(userId: String, missionName: String): Mission {
-        return Mission(
-            missionName,
-            MissionInfo(
-                missionName = missionName,
-                userId = userId,
-                totalStamp = missionCount.value!!,
-                startDate = missionStartDate.value!!,
-                dueDate = missionEndDate.value!!
-            )
+    private fun getMissionInfo(userId: String, missionName: String): MissionInfo {
+        return MissionInfo(
+            missionName = missionName,
+            userId = userId,
+            totalStamp = missionCount.value!!,
+            startDate = missionStartDate.value!!,
+            dueDate = missionEndDate.value!!
         )
     }
 


### PR DESCRIPTION
# ❗️ 이슈 트래킹
- #23 

# 💡 작업목록
- 미션 생성 후 데이터베이스에 저장 방법 수정
  - 미션 아이디 파이어베이스로부터 받아온 후 저장
  - updateChildren 사용해서 missions에 missionInfo 추가, currentGroup의 missionList에 missionInfo 추가를 한번에 처리

