### PR TITLE
[10-3] 구성원의 미션리스트 화면으로 이동

### DIFF
--- a/app/src/main/java/com/ariari/mowoori/ui/main/MainActivity.kt
+++ b/app/src/main/java/com/ariari/mowoori/ui/main/MainActivity.kt
@@ -42,7 +42,7 @@ class MainActivity : AppCompatActivity() {
             when (destination.id) {
                 R.id.homeFragment, R.id.membersFragment -> showBottomNav()
                 R.id.missionsFragment -> {
-                    if (arguments != null) {
+                    if (arguments?.get("userId") != null) {
                         // 구성원의 미션
                         hideBottomNav()
                     } else {

--- a/app/src/main/java/com/ariari/mowoori/ui/main/MainActivity.kt
+++ b/app/src/main/java/com/ariari/mowoori/ui/main/MainActivity.kt
@@ -38,12 +38,17 @@ class MainActivity : AppCompatActivity() {
     }
 
     private fun setBottomNavVisibility() {
-        navController.addOnDestinationChangedListener { _, destination, _ ->
+        navController.addOnDestinationChangedListener { _, destination, arguments ->
             when (destination.id) {
                 R.id.homeFragment, R.id.membersFragment -> showBottomNav()
                 R.id.missionsFragment -> {
-                    // 나의 미션 or 구성원의 미션에 따라 달라짐.
-                    showBottomNav()
+                    if (arguments != null) {
+                        // 구성원의 미션
+                        hideBottomNav()
+                    } else {
+                        // 나의 미션
+                        showBottomNav()
+                    }
                 }
                 else -> hideBottomNav()
             }

--- a/app/src/main/java/com/ariari/mowoori/ui/members/MembersFragment.kt
+++ b/app/src/main/java/com/ariari/mowoori/ui/members/MembersFragment.kt
@@ -41,8 +41,8 @@ class MembersFragment : BaseFragment<FragmentMembersBinding>(R.layout.fragment_m
     }
 
     private fun setLoadingObserver() {
-        membersViewModel.loadingEvent.observe(viewLifecycleOwner, EventObserver {
-            if (it) ProgressDialogManager.instance.show(requireContext())
+        membersViewModel.loadingEvent.observe(viewLifecycleOwner, EventObserver { isLoading ->
+            if (isLoading) ProgressDialogManager.instance.show(requireContext())
             else ProgressDialogManager.instance.clear()
         })
     }

--- a/app/src/main/java/com/ariari/mowoori/ui/members/MembersFragment.kt
+++ b/app/src/main/java/com/ariari/mowoori/ui/members/MembersFragment.kt
@@ -8,6 +8,8 @@ import android.os.Bundle
 import android.view.View
 import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.viewModels
+import androidx.navigation.NavDirections
+import androidx.navigation.fragment.findNavController
 import com.ariari.mowoori.R
 import com.ariari.mowoori.base.BaseFragment
 import com.ariari.mowoori.databinding.FragmentMembersBinding
@@ -23,7 +25,7 @@ import dagger.hilt.android.AndroidEntryPoint
 @AndroidEntryPoint
 class MembersFragment : BaseFragment<FragmentMembersBinding>(R.layout.fragment_members) {
     private val membersViewModel: MembersViewModel by viewModels()
-    private val membersAdapter = MembersAdapter()
+    private val membersAdapter by lazy { MembersAdapter { user -> moveToMissionsFragment(user) } }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
@@ -53,14 +55,14 @@ class MembersFragment : BaseFragment<FragmentMembersBinding>(R.layout.fragment_m
         })
     }
 
-    private fun setCurrentGroupObserver(){
-        membersViewModel.currentGroup.observe(viewLifecycleOwner){
+    private fun setCurrentGroupObserver() {
+        membersViewModel.currentGroup.observe(viewLifecycleOwner) {
             membersViewModel.fetchMemberList()
         }
     }
 
-    private fun setMembersListObserver(){
-        membersViewModel.membersList.observe(viewLifecycleOwner){
+    private fun setMembersListObserver() {
+        membersViewModel.membersList.observe(viewLifecycleOwner) {
             membersAdapter.submitList(it)
             membersViewModel.setLoadingEvent(false)
         }
@@ -99,6 +101,12 @@ class MembersFragment : BaseFragment<FragmentMembersBinding>(R.layout.fragment_m
             putExtra(Intent.EXTRA_TEXT, text)
         }
         startActivity(shareIntent)
+    }
+
+    private fun moveToMissionsFragment(user: User) {
+        findNavController().navigate(
+            MembersFragmentDirections.actionMembersFragmentToMissionsFragment(user)
+        )
     }
 
 }

--- a/app/src/main/java/com/ariari/mowoori/ui/members/MembersViewModel.kt
+++ b/app/src/main/java/com/ariari/mowoori/ui/members/MembersViewModel.kt
@@ -19,7 +19,6 @@ import javax.inject.Inject
 class MembersViewModel @Inject constructor(
     private val membersRepository: MembersRepository,
 ) : ViewModel() {
-
     private val _loadingEvent = MutableLiveData<Event<Boolean>>()
     val loadingEvent: LiveData<Event<Boolean>> get() = _loadingEvent
 

--- a/app/src/main/java/com/ariari/mowoori/ui/members/adapter/MembersAdapter.kt
+++ b/app/src/main/java/com/ariari/mowoori/ui/members/adapter/MembersAdapter.kt
@@ -8,11 +8,22 @@ import androidx.recyclerview.widget.RecyclerView
 import com.ariari.mowoori.databinding.ItemMembersBinding
 import com.ariari.mowoori.ui.register.entity.User
 
-class MembersAdapter : ListAdapter<User, MembersAdapter.MembersViewHolder>(membersDiffUtil) {
-    class MembersViewHolder(private val binding: ItemMembersBinding) :
-        RecyclerView.ViewHolder(binding.root) {
+class MembersAdapter(
+    private val clickEvent: (User) -> Unit
+) : ListAdapter<User, MembersAdapter.MembersViewHolder>(membersDiffUtil) {
+    class MembersViewHolder(
+        private val binding: ItemMembersBinding,
+        private val clickEvent: (User) -> Unit
+    ) : RecyclerView.ViewHolder(binding.root) {
+
+        init {
+            itemView.setOnClickListener {
+                clickEvent(requireNotNull(binding.user))
+            }
+        }
+
         fun bind(user: User) {
-            binding.userInfo = user.userInfo
+            binding.user = user
         }
     }
 
@@ -22,7 +33,7 @@ class MembersAdapter : ListAdapter<User, MembersAdapter.MembersViewHolder>(membe
                 LayoutInflater.from(parent.context),
                 parent,
                 false
-            )
+            ), clickEvent
         )
 
     override fun onBindViewHolder(holder: MembersViewHolder, position: Int) {

--- a/app/src/main/java/com/ariari/mowoori/ui/missions/MissionsFragment.kt
+++ b/app/src/main/java/com/ariari/mowoori/ui/missions/MissionsFragment.kt
@@ -9,6 +9,7 @@ import com.ariari.mowoori.base.BaseFragment
 import com.ariari.mowoori.databinding.FragmentMissionsBinding
 import com.ariari.mowoori.ui.missions.adapter.MissionsAdapter
 import com.ariari.mowoori.util.EventObserver
+import com.ariari.mowoori.widget.ProgressDialogManager
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
@@ -23,18 +24,26 @@ class MissionsFragment : BaseFragment<FragmentMissionsBinding>(R.layout.fragment
         super.onViewCreated(view, savedInstanceState)
         binding.lifecycleOwner = viewLifecycleOwner
         binding.viewModel = missionsViewModel
-
+        missionsViewModel.setLoadingEvent(true)
         setMissionsRvAdapter()
         setObserver()
         getUserName()
     }
 
     private fun setObserver() {
+        setLoadingObserver()
         setPlusBtnClickObserver()
         setMissionsTypeObserver()
         setMissionsListObserver()
         setItemClickObserver()
         setUserNameObserver()
+    }
+
+    private fun setLoadingObserver() {
+        missionsViewModel.loadingEvent.observe(viewLifecycleOwner, EventObserver { isLoading ->
+            if (isLoading) ProgressDialogManager.instance.show(requireContext())
+            else ProgressDialogManager.instance.clear()
+        })
     }
 
     private fun setMissionsRvAdapter() {
@@ -57,6 +66,7 @@ class MissionsFragment : BaseFragment<FragmentMissionsBinding>(R.layout.fragment
     private fun setMissionsListObserver() {
         missionsViewModel.missionsList.observe(viewLifecycleOwner) { missionsList ->
             missionsAdapter.submitList(missionsList)
+            missionsViewModel.setLoadingEvent(false)
         }
     }
 

--- a/app/src/main/java/com/ariari/mowoori/ui/missions/MissionsFragment.kt
+++ b/app/src/main/java/com/ariari/mowoori/ui/missions/MissionsFragment.kt
@@ -30,7 +30,6 @@ class MissionsFragment : BaseFragment<FragmentMissionsBinding>(R.layout.fragment
         missionsViewModel.setLoadingEvent(true)
         setMissionsRvAdapter()
         setObserver()
-        getUserName()
     }
 
     private fun setObserver() {
@@ -81,10 +80,6 @@ class MissionsFragment : BaseFragment<FragmentMissionsBinding>(R.layout.fragment
                 )
             )
         })
-    }
-
-    private fun getUserName() {
-        missionsViewModel.loadUserName()
     }
 
     private fun setUserNameObserver() {

--- a/app/src/main/java/com/ariari/mowoori/ui/missions/MissionsFragment.kt
+++ b/app/src/main/java/com/ariari/mowoori/ui/missions/MissionsFragment.kt
@@ -4,10 +4,12 @@ import android.os.Bundle
 import android.view.View
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
+import androidx.navigation.fragment.navArgs
 import com.ariari.mowoori.R
 import com.ariari.mowoori.base.BaseFragment
 import com.ariari.mowoori.databinding.FragmentMissionsBinding
 import com.ariari.mowoori.ui.missions.adapter.MissionsAdapter
+import com.ariari.mowoori.ui.register.entity.User
 import com.ariari.mowoori.util.EventObserver
 import com.ariari.mowoori.widget.ProgressDialogManager
 import dagger.hilt.android.AndroidEntryPoint
@@ -18,6 +20,7 @@ class MissionsFragment : BaseFragment<FragmentMissionsBinding>(R.layout.fragment
     private val missionsAdapter: MissionsAdapter by lazy {
         MissionsAdapter(missionsViewModel)
     }
+    private val args by navArgs<MissionsFragmentArgs>()
     private lateinit var userName: String
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
@@ -48,7 +51,7 @@ class MissionsFragment : BaseFragment<FragmentMissionsBinding>(R.layout.fragment
 
     private fun setMissionsRvAdapter() {
         binding.rvMissions.adapter = missionsAdapter
-        missionsViewModel.loadMissionsList()
+        missionsViewModel.sendUserToLoadMissions(args.userId)
     }
 
     private fun setPlusBtnClickObserver() {
@@ -59,7 +62,7 @@ class MissionsFragment : BaseFragment<FragmentMissionsBinding>(R.layout.fragment
 
     private fun setMissionsTypeObserver() {
         missionsViewModel.missionsType.observe(viewLifecycleOwner, EventObserver {
-            missionsViewModel.loadMissionsList()
+            missionsViewModel.sendUserToLoadMissions(args.userId)
         })
     }
 

--- a/app/src/main/java/com/ariari/mowoori/ui/missions/MissionsViewModel.kt
+++ b/app/src/main/java/com/ariari/mowoori/ui/missions/MissionsViewModel.kt
@@ -18,6 +18,9 @@ import javax.inject.Inject
 class MissionsViewModel @Inject constructor(
     private val missionsRepository: MissionsRepository
 ) : ViewModel() {
+    private val _loadingEvent = MutableLiveData<Event<Boolean>>()
+    val loadingEvent: LiveData<Event<Boolean>> get() = _loadingEvent
+
     private val _plusBtnClick = MutableLiveData<Event<Boolean>>()
     val plusBtnClick: LiveData<Event<Boolean>> = _plusBtnClick
 
@@ -33,6 +36,10 @@ class MissionsViewModel @Inject constructor(
     private val _userName = MutableLiveData<Event<String>>()
     val userName: LiveData<Event<String>> get() = _userName
 
+    fun setLoadingEvent(isLoading: Boolean) {
+        _loadingEvent.value = Event(isLoading)
+    }
+
     fun setPlusBtnClick() {
         _plusBtnClick.value = Event(true)
     }
@@ -43,14 +50,17 @@ class MissionsViewModel @Inject constructor(
 
     fun setNotDoneType() {
         _missionsType.value = Event(NOT_DONE_TYPE)
+        setLoadingEvent(true)
     }
 
     fun setDoneType() {
         _missionsType.value = Event(DONE_TYPE)
+        setLoadingEvent(true)
     }
 
     fun setFailType() {
         _missionsType.value = Event(FAIL_TYPE)
+        setLoadingEvent(true)
     }
 
     fun loadMissionsList() {

--- a/app/src/main/java/com/ariari/mowoori/ui/missions/MissionsViewModel.kt
+++ b/app/src/main/java/com/ariari/mowoori/ui/missions/MissionsViewModel.kt
@@ -65,11 +65,13 @@ class MissionsViewModel @Inject constructor(
     }
 
     fun sendUserToLoadMissions(user: User?) {
-        viewModelScope.launch(Dispatchers.IO) {
-            if (user != null) {
-                loadMissionsList(user)
-            } else {
+        if (user != null) {
+            loadUserName(user.userInfo.nickname)
+            loadMissionsList(user)
+        } else {
+            viewModelScope.launch(Dispatchers.IO) {
                 missionsRepository.getUser().onSuccess { user ->
+                    loadUserName(user.userInfo.nickname)
                     loadMissionsList(user)
                 }.onFailure { throw Exception("get User Exception!!") }
             }
@@ -108,16 +110,8 @@ class MissionsViewModel @Inject constructor(
         }
     }
 
-    fun loadUserName() {
-        viewModelScope.launch(Dispatchers.IO) {
-            missionsRepository.getUser()
-                .onSuccess {
-                    _userName.postValue(Event(it.userInfo.nickname))
-                }
-                .onFailure {
-                    println("${it.message}")
-                }
-        }
+    private fun loadUserName(userName:String) {
+        _userName.postValue(Event(userName))
     }
 
     companion object {

--- a/app/src/main/res/layout/fragment_missions.xml
+++ b/app/src/main/res/layout/fragment_missions.xml
@@ -29,7 +29,7 @@
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent"
             app:onPlusClick="@{viewModel::setPlusBtnClick}"
-            app:text="@string/missions_my_mission"
+            app:titleViewText="@{@string/missions_my_mission(viewModel.userName.peekContent())}"
             app:titleViewMode="@{TitleViewMode.TITLE_VIEW_PLUS_BUTTON}" />
 
         <TextView

--- a/app/src/main/res/layout/item_members.xml
+++ b/app/src/main/res/layout/item_members.xml
@@ -6,8 +6,8 @@
     <data>
 
         <variable
-            name="userInfo"
-            type="com.ariari.mowoori.ui.register.entity.UserInfo" />
+            name="user"
+            type="com.ariari.mowoori.ui.register.entity.User" />
     </data>
 
     <androidx.constraintlayout.widget.ConstraintLayout
@@ -20,7 +20,7 @@
 
         <ImageView
             android:id="@+id/iv_members_profile"
-            imageUrl="@{userInfo.profileImage}"
+            imageUrl="@{user.userInfo.profileImage}"
             isCircle="@{true}"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
@@ -38,7 +38,7 @@
             android:layout_marginTop="20dp"
             android:layout_marginBottom="22dp"
             android:gravity="center"
-            android:text="@{userInfo.nickname}"
+            android:text="@{user.userInfo.nickname}"
             android:textColor="@color/black"
             android:textSize="18sp"
             app:layout_constraintBottom_toBottomOf="parent"

--- a/app/src/main/res/navigation/main_navigation.xml
+++ b/app/src/main/res/navigation/main_navigation.xml
@@ -34,6 +34,7 @@
         tools:layout="@layout/fragment_missions">
         <argument
             android:name="userId"
+            android:defaultValue="@null"
             app:argType="com.ariari.mowoori.ui.register.entity.User"
             app:nullable="true" />
         <action

--- a/app/src/main/res/navigation/main_navigation.xml
+++ b/app/src/main/res/navigation/main_navigation.xml
@@ -22,12 +22,20 @@
         android:id="@+id/membersFragment"
         android:name="com.ariari.mowoori.ui.members.MembersFragment"
         android:label="MembersFragment"
-        tools:layout="@layout/fragment_members" />
+        tools:layout="@layout/fragment_members">
+        <action
+            android:id="@+id/action_membersFragment_to_missionsFragment"
+            app:destination="@id/missionsFragment" />
+    </fragment>
     <fragment
         android:id="@+id/missionsFragment"
         android:name="com.ariari.mowoori.ui.missions.MissionsFragment"
         android:label="MissionsFragment"
         tools:layout="@layout/fragment_missions">
+        <argument
+            android:name="userId"
+            app:argType="com.ariari.mowoori.ui.register.entity.User"
+            app:nullable="true" />
         <action
             android:id="@+id/action_missionsFragment_to_missionsAddFragment"
             app:destination="@id/missionsAddFragment" />

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -58,7 +58,7 @@
 
     <!-- MissionsFragment -->
     <string name="item_missions_stamp_count">%d/%d</string>
-    <string name="missions_my_mission">나의 미션</string>
+    <string name="missions_my_mission">%s님의 미션</string>
     <string name="missions_not_done">미완료</string>
     <string name="missions_done">완료</string>
     <string name="missions_fail">실패</string>


### PR DESCRIPTION
# ❗️ 이슈 트래킹
- #20

# 💡 작업목록
- '우리'들 탭에서 구성원 아이템 클릭 시 미션 리스트 화면으로 이동 (화면이동만 구현)
  - 이때, 나의 미션이면 showBottomNavigation, 구성원의 미션이면 hideBottomNavigation
-  미션 불러오기 전 로딩화면 추가
- '우리'들 탭에서 구성원 아이템 클릭 시 구성원의 유저정보를 미션 리스트 화면으로 전달 후 구성원의 미션을 띄우도록 구현
- 미션 탭 상단에 미션 주인의 이름이 뜨도록 구현
