### PR TITLE
[5-1] 그룹 선택 어댑터 변경 및 그룹 아이템 배경색 변경

### DIFF
--- a/app/src/main/java/com/ariari/mowoori/ui/home/HomeFragment.kt
+++ b/app/src/main/java/com/ariari/mowoori/ui/home/HomeFragment.kt
@@ -86,7 +86,6 @@ class HomeFragment : BaseFragment<FragmentHomeBinding>(R.layout.fragment_home) {
         binding.viewModel = homeViewModel
         binding.layoutHomeSnowmanFaceLv4.viewModel = homeViewModel
         setUserInfoObserver()
-        setCurrentGroupInfoObserver()
         setGroupInfoListObserver()
         setDrawerOpenListener()
         setDrawerAdapter()
@@ -109,12 +108,6 @@ class HomeFragment : BaseFragment<FragmentHomeBinding>(R.layout.fragment_home) {
     private fun setUserInfoObserver() {
         homeViewModel.userInfo.observe(viewLifecycleOwner, EventObserver { userInfo ->
             homeViewModel.setGroupInfoList(userInfo)
-        })
-    }
-
-    private fun setCurrentGroupInfoObserver() {
-        homeViewModel.currentGroupInfo.observe(viewLifecycleOwner, {
-            adapter.submitList(adapter.currentList)
         })
     }
 
@@ -206,24 +199,22 @@ class HomeFragment : BaseFragment<FragmentHomeBinding>(R.layout.fragment_home) {
     }
 
     private fun updateWinterAnimation(snowmanLevel: SnowmanLevel) {
-        viewLifecycleOwner.lifecycleScope.launch {
-            when (snowmanLevel) {
-                SnowmanLevel.LV1 -> {
-                    // 1단계 - 눈만 내리는 애니메이션
-                }
-                SnowmanLevel.LV2 -> {
-                    // 2단계 눈사람 - 얼굴 통통 애니메이션
-                    binding.ivHomeSnowmanFaceLv2.isVisible = true
-                    snowmanLv2Animator.start()
-                }
-                SnowmanLevel.LV3 -> {
-                    // 3단계 눈사람 - 얼굴 몸통 합체 애니메이션
-                    binding.ivHomeSnowmanFaceLv3.setImageResource(R.drawable.ic_snowman_face_3_rotate)
-                    snowmanLv3Animator.start()
-                }
-                SnowmanLevel.LV4 -> {
-                    snowmanLv4Animator.start()
-                }
+        when (snowmanLevel) {
+            SnowmanLevel.LV1 -> {
+                // 1단계 - 눈만 내리는 애니메이션
+            }
+            SnowmanLevel.LV2 -> {
+                // 2단계 눈사람 - 얼굴 통통 애니메이션
+                binding.ivHomeSnowmanFaceLv2.isVisible = true
+                snowmanLv2Animator.start()
+            }
+            SnowmanLevel.LV3 -> {
+                // 3단계 눈사람 - 얼굴 몸통 합체 애니메이션
+                binding.ivHomeSnowmanFaceLv3.setImageResource(R.drawable.ic_snowman_face_3_rotate)
+                snowmanLv3Animator.start()
+            }
+            SnowmanLevel.LV4 -> {
+                snowmanLv4Animator.start()
             }
         }
     }

--- a/app/src/main/java/com/ariari/mowoori/ui/home/HomeFragment.kt
+++ b/app/src/main/java/com/ariari/mowoori/ui/home/HomeFragment.kt
@@ -12,7 +12,6 @@ import com.ariari.mowoori.R
 import com.ariari.mowoori.base.BaseFragment
 import com.ariari.mowoori.databinding.FragmentHomeBinding
 import com.ariari.mowoori.ui.home.adapter.DrawerAdapter
-import com.ariari.mowoori.ui.home.adapter.DrawerAdapterDecoration
 import com.ariari.mowoori.ui.home.animator.SnowAnimator
 import com.ariari.mowoori.ui.home.animator.SnowmanLv2Animator
 import com.ariari.mowoori.ui.home.animator.SnowmanLv3Animator
@@ -91,10 +90,10 @@ class HomeFragment : BaseFragment<FragmentHomeBinding>(R.layout.fragment_home) {
         setGroupInfoListObserver()
         setDrawerOpenListener()
         setDrawerAdapter()
-        setRecyclerViewDecoration()
         setObservers()
         setClickListener()
         setMenuListener()
+        setPlusClickListener()
     }
 
     override fun onDestroyView() {
@@ -114,15 +113,14 @@ class HomeFragment : BaseFragment<FragmentHomeBinding>(R.layout.fragment_home) {
     }
 
     private fun setCurrentGroupInfoObserver() {
-        homeViewModel.currentGroupInfo.observe(viewLifecycleOwner, { group ->
-            adapter.notifyDataSetChanged()
+        homeViewModel.currentGroupInfo.observe(viewLifecycleOwner, {
+            adapter.submitList(adapter.currentList)
         })
     }
 
     private fun setGroupInfoListObserver() {
         homeViewModel.groupList.observe(viewLifecycleOwner, { groupList ->
-            adapter.groups = groupList
-            adapter.notifyDataSetChanged()
+            adapter.submitList(groupList)
         })
     }
 
@@ -164,11 +162,6 @@ class HomeFragment : BaseFragment<FragmentHomeBinding>(R.layout.fragment_home) {
             }
         })
         binding.rvDrawer.adapter = adapter
-    }
-
-    private fun setRecyclerViewDecoration() {
-        val itemDecoration = DrawerAdapterDecoration()
-        binding.rvDrawer.addItemDecoration(itemDecoration)
     }
 
     private fun setObservers() {
@@ -232,6 +225,12 @@ class HomeFragment : BaseFragment<FragmentHomeBinding>(R.layout.fragment_home) {
                     snowmanLv4Animator.start()
                 }
             }
+        }
+    }
+
+    private fun setPlusClickListener() {
+        binding.layoutDrawerHeader.tvDrawerHeaderAdd.setOnClickListener {
+            findNavController().navigate(R.id.action_homeFragment_to_inviteCheckFragment)
         }
     }
 }

--- a/app/src/main/java/com/ariari/mowoori/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/com/ariari/mowoori/ui/home/HomeViewModel.kt
@@ -74,12 +74,16 @@ class HomeViewModel @Inject constructor(
     }
 
     fun setCurrentGroupInfo(groupId: String) {
-        _groupList.value?.let { groupList ->
-            groupList.forEach {
-                it.selected = it.groupId == groupId
-                if (it.selected) _currentGroupInfo.postValue(it)
-            }
+        val currentGroupList = groupList.value ?: return
+        val tempGroupList = mutableListOf<Group>()
+        currentGroupList.forEach {
+            tempGroupList.add(it.copy())
         }
+        tempGroupList.forEach {
+            it.selected = it.groupId == groupId
+            if (it.selected) _currentGroupInfo.value = it
+        }
+        _groupList.value = tempGroupList
         homeRepository.setCurrentGroupId(groupId)
     }
 

--- a/app/src/main/java/com/ariari/mowoori/ui/home/adapter/DrawerAdapter.kt
+++ b/app/src/main/java/com/ariari/mowoori/ui/home/adapter/DrawerAdapter.kt
@@ -1,72 +1,45 @@
 package com.ariari.mowoori.ui.home.adapter
 
 import android.view.LayoutInflater
-import android.view.View
 import android.view.ViewGroup
-import androidx.navigation.findNavController
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
 import com.ariari.mowoori.R
 import com.ariari.mowoori.databinding.ItemDrawerGroupBinding
-import com.ariari.mowoori.databinding.ItemDrawerHeaderBinding
 import com.ariari.mowoori.ui.home.entity.Group
-import com.ariari.mowoori.ui.home.entity.GroupInfo
 
 class DrawerAdapter(private val listener: OnItemClickListener) :
-    RecyclerView.Adapter<RecyclerView.ViewHolder>() {
+    ListAdapter<Group, DrawerAdapter.GroupViewHolder>(diffUtil) {
+
+    companion object {
+        val diffUtil = object : DiffUtil.ItemCallback<Group>() {
+            override fun areItemsTheSame(oldItem: Group, newItem: Group): Boolean {
+                return oldItem.groupId == newItem.groupId
+            }
+
+            override fun areContentsTheSame(oldItem: Group, newItem: Group): Boolean {
+                return oldItem == newItem
+            }
+        }
+    }
 
     interface OnItemClickListener {
         fun itemClick(groupId: String)
     }
 
-    companion object {
-        private const val HEADER = 0
-        private const val GROUP = 1
-    }
-
-    var groups = listOf<Group>()
-
-    override fun getItemViewType(position: Int): Int {
-        return when (position) {
-            0 -> HEADER
-            else -> GROUP
-        }
-    }
-
-    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): RecyclerView.ViewHolder {
-        return when (viewType) {
-            HEADER -> HeaderViewHolder(
-                ItemDrawerHeaderBinding.inflate(
-                    LayoutInflater.from(parent.context),
-                    parent,
-                    false
-                )
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): GroupViewHolder {
+        return GroupViewHolder(
+            ItemDrawerGroupBinding.inflate(
+                LayoutInflater.from(parent.context),
+                parent,
+                false
             )
-            else -> GroupViewHolder(
-                ItemDrawerGroupBinding.inflate(
-                    LayoutInflater.from(parent.context),
-                    parent,
-                    false
-                )
-            )
-        }
+        )
     }
 
-    override fun onBindViewHolder(holder: RecyclerView.ViewHolder, position: Int) {
-        when (holder) {
-            is HeaderViewHolder -> Unit // nothing to bind
-            else -> (holder as GroupViewHolder).bind(groups[position - 1])
-        }
-    }
-
-    override fun getItemCount(): Int = groups.size + 1
-
-    inner class HeaderViewHolder(binding: ItemDrawerHeaderBinding) :
-        RecyclerView.ViewHolder(binding.root) {
-        init {
-            binding.tvDrawerHeaderAdd.setOnClickListener {
-                it.findNavController().navigate(R.id.action_homeFragment_to_inviteCheckFragment)
-            }
-        }
+    override fun onBindViewHolder(holder: GroupViewHolder, position: Int) {
+        holder.bind(getItem(position))
     }
 
     inner class GroupViewHolder(private val binding: ItemDrawerGroupBinding) :

--- a/app/src/main/res/layout/fragment_home.xml
+++ b/app/src/main/res/layout/fragment_home.xml
@@ -208,19 +208,25 @@
 
         </androidx.constraintlayout.widget.ConstraintLayout>
 
-        <com.google.android.material.navigation.NavigationView
-            android:id="@+id/nav_view_drawer"
-            android:layout_width="wrap_content"
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:layout_gravity="start">
+            android:layout_gravity="start"
+            android:background="@color/white">
+
+            <include
+                android:id="@+id/layout_drawer_header"
+                layout="@layout/item_drawer_header" />
 
             <androidx.recyclerview.widget.RecyclerView
                 android:id="@+id/rv_drawer"
                 android:layout_width="match_parent"
-                android:layout_height="match_parent"
+                android:layout_height="0dp"
                 app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/layout_drawer_header"
                 tools:listitem="@layout/item_drawer_group" />
+        </androidx.constraintlayout.widget.ConstraintLayout>
 
-        </com.google.android.material.navigation.NavigationView>
     </androidx.drawerlayout.widget.DrawerLayout>
 </layout>


### PR DESCRIPTION
# ❗️ 이슈 트래킹
- #9 

# 💡 작업목록
- 그룹 리스트 목록 어댑터를 리스트 어댑터로 변경
- 그룹 아이템 클릭 시 클릭한 아이템의 배경색상 즉시 변경

# ❓ 고민과 해결
- 그룹 아이템의 클릭 여부를 Group 데이터 클래스의 속성 값이 변경되도록 주었는데, DiffUtil 이 속성 변경을 인식하기 위해선 기존의 그룹을 copy 한 객체를 그룹 리스트에 새로 삽입하고 submitList 를 통해 oldItem 과 newItem 비교를 해주어야 했다. 

