### PR TITLE
[15-1] 미션 인증화면 카메라 기능 구현 및 사용자 권한 추가

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,6 +2,14 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.ariari.mowoori">
 
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.CAMERA" />
+
+    <uses-feature
+        android:name="android.hardware.camera"
+        android:required="true" />
+
     <application
         android:name="com.ariari.mowoori.MoWooriApp"
         android:allowBackup="true"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -33,6 +33,16 @@
         </activity>
         <activity android:name=".ui.register.RegisterActivity" />
         <activity android:name=".ui.main.MainActivity" />
+
+        <provider
+            android:name="androidx.core.content.FileProvider"
+            android:authorities="com.ariari.mowoori.fileProvider"
+            android:exported="false"
+            android:grantUriPermissions="true">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/file_paths"/>
+        </provider>
     </application>
 
 </manifest>

--- a/app/src/main/java/com/ariari/mowoori/ui/stamp_detail/StampDetailFragment.kt
+++ b/app/src/main/java/com/ariari/mowoori/ui/stamp_detail/StampDetailFragment.kt
@@ -2,12 +2,14 @@ package com.ariari.mowoori.ui.stamp_detail
 
 import android.app.Activity
 import android.content.pm.PackageManager
+import android.net.Uri
 import android.os.Bundle
+import android.os.Environment
 import android.view.View
 import android.view.inputmethod.InputMethodManager
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.core.content.ContextCompat
-import androidx.core.net.toUri
+import androidx.core.content.FileProvider
 import androidx.core.view.isInvisible
 import androidx.core.view.isVisible
 import androidx.fragment.app.viewModels
@@ -22,6 +24,7 @@ import com.ariari.mowoori.ui.stamp.entity.DetailMode
 import com.ariari.mowoori.ui.stamp_detail.entity.PictureType
 import com.ariari.mowoori.util.EventObserver
 import com.ariari.mowoori.util.LogUtil
+import com.ariari.mowoori.util.getCurrentDateTime
 import com.ariari.mowoori.util.toastMessage
 import com.ariari.mowoori.widget.PictureDialogFragment
 import com.bumptech.glide.Glide
@@ -29,29 +32,28 @@ import com.bumptech.glide.load.resource.bitmap.CenterCrop
 import com.bumptech.glide.load.resource.bitmap.RoundedCorners
 import dagger.hilt.android.AndroidEntryPoint
 import timber.log.Timber
+import java.io.File
 
 @AndroidEntryPoint
 class StampDetailFragment :
     BaseFragment<FragmentStampDetailBinding>(R.layout.fragment_stamp_detail) {
-    private val safeArgs: StampDetailFragmentArgs by navArgs()
     private val viewModel: StampDetailViewModel by viewModels()
+    private val safeArgs: StampDetailFragmentArgs by navArgs()
     private lateinit var detailInfo: DetailInfo
+
+    private var currentPhotoPath: String? = null
+    private var providerUri: Uri? = null
 
     private val activityGalleryLauncher =
         registerForActivityResult(ActivityResultContracts.GetContent()) {
-            viewModel.setPictureUri(it)
-            Glide.with(requireContext())
-                .load(it)
-                .override(300, 300)
-                .transform(CenterCrop(), RoundedCorners(16))
-                .into(binding.ivStampDetail)
-            binding.tvStampDetailIcon.isVisible = false
+            saveCurrentPicture(it)
         }
 
     private val activityPictureLauncher =
         registerForActivityResult(ActivityResultContracts.TakePicture()) { success ->
             if (success) {
                 LogUtil.log("takePictureContent", success.toString())
+                saveCurrentPicture(providerUri)
             } else {
                 LogUtil.log("takePictureContent", success.toString())
             }
@@ -60,9 +62,7 @@ class StampDetailFragment :
     private val activityPermissionLauncher =
         registerForActivityResult(ActivityResultContracts.RequestPermission()) { isGranted ->
             if (isGranted) {
-                activityPictureLauncher.launch("image/temp".toUri())
-            } else {
-                toastMessage("사진 촬영을 위해서는 카메라 권한이 필요합니다.")
+                savePhoto()
             }
         }
 
@@ -76,25 +76,43 @@ class StampDetailFragment :
         super.onViewCreated(view, savedInstanceState)
         binding.lifecycleOwner = viewLifecycleOwner
         binding.viewModel = viewModel
+        init()
+        setListener()
+        setObserver()
+        setDetailTransitionName()
+    }
+
+    private fun init() {
         setDetailInfo()
         setEditMode()
         setBtnVisible()
-        setDetailTransitionName()
         setUserName()
         setMissionId()
         setMissionName()
-        setPicture()
         setComment()
+    }
+
+    private fun setListener() {
+        setBtnCertifyListener()
+        setPictureClickListener()
         setRootClick()
+    }
+
+    private fun setObserver() {
         setIsMissionPostedObserver()
         setCloseBtnClickObserver()
         setIsCertifyObserver()
-        setBtnCertifyListener()
         setCommentObserver()
     }
 
     private fun setDetailInfo() {
         detailInfo = safeArgs.detailInfo
+    }
+
+    private fun setEditMode() {
+        if (detailInfo.detailMode == DetailMode.INQUIRY) {
+            binding.etStampDetailComment.keyListener = null
+        }
     }
 
     private fun setBtnVisible() {
@@ -117,23 +135,11 @@ class StampDetailFragment :
         viewModel.setMissionName(detailInfo.missionName)
     }
 
-    private fun setEditMode() {
-        if (detailInfo.detailMode == DetailMode.INQUIRY) {
-            binding.etStampDetailComment.keyListener = null
-        }
-    }
-
     private fun setComment() {
         viewModel.setComment(detailInfo.stampInfo.comment)
     }
 
-    private fun setPicture() {
-        binding.ivStampDetail.setOnClickListener {
-            PictureDialogFragment(onClick).show(
-                requireActivity().supportFragmentManager,
-                "PictureDialogFragment"
-            )
-        }
+    private fun setPictureClickListener() {
         if (detailInfo.stampInfo.pictureUrl != "") {
             Glide.with(requireContext())
                 .load(detailInfo.stampInfo.pictureUrl)
@@ -141,6 +147,20 @@ class StampDetailFragment :
                 .transform(CenterCrop(), RoundedCorners(16))
                 .into(binding.ivStampDetail)
             binding.tvStampDetailIcon.isInvisible = true
+        } else {
+            binding.ivStampDetail.setOnClickListener {
+                PictureDialogFragment(onClick).show(
+                    requireActivity().supportFragmentManager,
+                    "PictureDialogFragment"
+                )
+            }
+        }
+    }
+
+    private fun setBtnCertifyListener() {
+        binding.btnStampDetailCertify.setOnClickListener {
+            viewModel.setComment(binding.etStampDetailComment.text.toString())
+            viewModel.postStamp()
         }
     }
 
@@ -159,9 +179,61 @@ class StampDetailFragment :
         if (!hasPermission(permission)) {
             activityPermissionLauncher.launch(permission)
         } else {
-            Timber.d("모든 권한이 승인되어 있어서 사진찍기 가능")
-            activityPictureLauncher.launch("image/temp".toUri())
+            savePhoto()
         }
+    }
+
+    private fun savePhoto() {
+        Timber.d("모든 권한이 승인되어 있어서 사진찍기 가능")
+        val photoFile: File?
+        try {
+            photoFile = createImageFile()
+            if (photoFile != null) {
+                providerUri = FileProvider.getUriForFile(
+                    requireContext(),
+                    "com.ariari.mowoori.fileProvider",
+                    photoFile
+                )
+                LogUtil.log("providerUri", providerUri.toString())
+                activityPictureLauncher.launch(providerUri)
+            }
+        } catch (exception: Exception) {
+            Timber.e("create Image File Error~~")
+        }
+    }
+
+    private fun createImageFile(): File {
+        Timber.d("createImageFile Start")
+        val timeStamp = getCurrentDateTime()
+        Timber.d(timeStamp)
+        val imageFileName = "${detailInfo.missionId}_$timeStamp.jpg"
+        Timber.d(imageFileName)
+        val storageDir = File(
+            requireContext().getExternalFilesDir(Environment.DIRECTORY_PICTURES)
+                .toString(),
+            "Mowoori"
+        )
+        // LogUtil.log("storageDir", storageDir.toString())
+
+        if (!storageDir.exists()) {
+            // Timber.d("make new dir")
+            storageDir.mkdirs()
+        }
+        val imageFile = File(storageDir, imageFileName)
+        // LogUtil.log("imageFile", imageFile.toString())
+        currentPhotoPath = imageFile.absolutePath
+        // LogUtil.log("currentPhotoPath", currentPhotoPath.toString())
+        return imageFile
+    }
+
+    private fun saveCurrentPicture(uri: Uri?) {
+        viewModel.setPictureUri(uri)
+        Glide.with(requireContext())
+            .load(uri)
+            .override(300, 300)
+            .transform(CenterCrop(), RoundedCorners(16))
+            .into(binding.ivStampDetail)
+        binding.tvStampDetailIcon.isVisible = false
     }
 
     private fun hasPermission(permission: String): Boolean {
@@ -210,13 +282,6 @@ class StampDetailFragment :
     private fun setCommentObserver() {
         viewModel.comment.observe(viewLifecycleOwner) {
             binding.etStampDetailComment.setText(it)
-        }
-    }
-
-    private fun setBtnCertifyListener() {
-        binding.btnStampDetailCertify.setOnClickListener {
-            viewModel.setComment(binding.etStampDetailComment.text.toString())
-            viewModel.postStamp()
         }
     }
 

--- a/app/src/main/java/com/ariari/mowoori/ui/stamp_detail/StampDetailViewModel.kt
+++ b/app/src/main/java/com/ariari/mowoori/ui/stamp_detail/StampDetailViewModel.kt
@@ -64,8 +64,10 @@ class StampDetailViewModel @Inject constructor(
         _comment.value = comment
     }
 
-    fun setPictureUri(uri: Uri) {
-        _pictureUri.value = uri
+    fun setPictureUri(uri: Uri?) {
+        uri?.let {
+            _pictureUri.value = it
+        }
     }
 
     fun setIsCertify(detailMode: DetailMode) {

--- a/app/src/main/java/com/ariari/mowoori/util/Util.kt
+++ b/app/src/main/java/com/ariari/mowoori/util/Util.kt
@@ -12,6 +12,10 @@ fun getCurrentDate(): Int {
     return dateFormat.format(today).toInt()
 }
 
+fun getCurrentDateTime(): String {
+    return SimpleDateFormat("yyyyMMdd_HHmmss").format(Date())
+}
+
 fun getCurrentDatePlusMonths(month: Int): Int {
     val dateFormat = SimpleDateFormat("yyyyMMdd", Locale.KOREA)
     val calendar = Calendar.getInstance().apply {

--- a/app/src/main/java/com/ariari/mowoori/widget/PictureDialogFragment.kt
+++ b/app/src/main/java/com/ariari/mowoori/widget/PictureDialogFragment.kt
@@ -21,7 +21,6 @@ class PictureDialogFragment(private val onClick: (pictureType: PictureType) -> U
         binding.containerDialogPictureCamera.setOnClickListener {
             onClick(PictureType.CAMERA)
             dismiss()
-            // TODO: 사진촬영
         }
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -104,7 +104,7 @@
     <string name="members_invite_code_copy_complete">초대코드가 클립보드에 복사되었습니다.</string>
 
     <!-- StampDetailFragment -->
-    <string name="stamp_detail_user">`%s` 님의</string>
+    <string name="stamp_detail_user">%s님의</string>
     <string name="stamp_detail_picture">인증 사진</string>
     <string name="stamp_detail_comment">한줄평</string>
     <string name="stamp_detail_hint">한줄평을 작성해주세요</string>

--- a/app/src/main/res/xml/file_paths.xml
+++ b/app/src/main/res/xml/file_paths.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<paths>
+    <external-path
+        name="hidden"
+        path="Android/data/com.ariari.mowoori/files/Pictures/Mowoori" />
+</paths>


### PR DESCRIPTION
# ❗️ 이슈 트래킹
- #26
- #28 

# 💡 작업목록
- 미션 인증 그림에서 카메라 사진도 가능하도록 구현
- 카메라를 위한 권한 요청 기능 구현

# ❓ 고민과 해결
- 사용자 권한 요청 시 2번이상 거부하면 다시 물어보지 않는데 이것을 해결해야겠다.(아직 해결X)
- startActivityForResult는 deprecated되었고 registerForActiviyResult를 사용하여 카메라 Activity, 갤러리 Activity 등 다양한 액티비티를 띄우고 그것으로부터 결과값을 받는 형식으로 정형화된 것 같다.
- Glide를 통해 url로 그림을 다운받아 넣어줄 경우에 roundCorner처리나 centerCrop, 크기 지정을 위해서 아래와 같이 Glide의 내장함수를 사용하여 구현했다.

```kotlin
            Glide.with(requireContext())
                .load(detailInfo.stampInfo.pictureUrl)
                .override(300, 300)
                .transform(CenterCrop(), RoundedCorners(16))
                .into(binding.ivStampDetail)
```

- 앱을 오래 켜두면 계속 꺼지는 현상이 일어나는데 왜 그런지 도통 모르겠다..ㅠㅠ
