### PR TITLE
[12-1, 21-1] 그룹 간 이동 시 Animation 처리 및 미션 생성 시 미션이름길이 제한 수정

### DIFF
--- a/app/src/main/java/com/ariari/mowoori/ui/home/HomeFragment.kt
+++ b/app/src/main/java/com/ariari/mowoori/ui/home/HomeFragment.kt
@@ -142,8 +142,8 @@ class HomeFragment : BaseFragment<FragmentHomeBinding>(R.layout.fragment_home) {
     private fun setDrawerAdapter() {
         adapter = DrawerAdapter(object : DrawerAdapter.OnItemClickListener {
             override fun itemClick(groupId: String) {
-                homeViewModel.setCurrentGroupInfo(groupId)
                 homeViewModel.cancelAnimator()
+                homeViewModel.setCurrentGroupInfo(groupId)
                 binding.drawerHome.close()
             }
         })

--- a/app/src/main/java/com/ariari/mowoori/ui/home/animator/SnowmanLv4Animator.kt
+++ b/app/src/main/java/com/ariari/mowoori/ui/home/animator/SnowmanLv4Animator.kt
@@ -84,95 +84,46 @@ class SnowmanLv4Animator(
                 })
             }
         showUpFirstExclamationAnimator =
-            getAnimatorFromResource(R.animator.animator_show_up, component.exclamations[0]).apply {
-                addListener(object : AnimatorListenerAdapter() {
-                    override fun onAnimationEnd(animation: Animator?) {
-                        super.onAnimationEnd(animation)
-                        showUpFirstExclamationAnimator.removeAllListeners()
-                    }
-                })
+            getAnimatorFromResource(R.animator.animator_show_up, component.exclamations[0])
+        showUpSecondExclamationAnimator =
+            getAnimatorFromResource(R.animator.animator_show_up, component.exclamations[1])
+
+        showUpLeftHeartAnimator =
+            getAnimatorFromResource(
+                R.animator.animator_show_up, component.hearts[0]
+            ).apply {
+                startDelay = 180L
             }
-        showUpSecondExclamationAnimator = getAnimatorFromResource(R.animator.animator_show_up,
-            component.exclamations[1]).apply {
-            addListener(object : AnimatorListenerAdapter() {
-                override fun onAnimationEnd(animation: Animator?) {
-                    super.onAnimationEnd(animation)
-                    showUpFirstExclamationAnimator.removeAllListeners()
-                }
-            })
-        }
+        showUpRightHeartAnimator =
+            getAnimatorFromResource(
+                R.animator.animator_show_up, component.hearts[1]
+            ).apply {
+                startDelay = 180L
+            }
+        showBigHeartAnimator =
+            getAnimatorFromResource(
+                R.animator.animator_show_big_heart, component.face.ivHomeBigHeart
+            )
 
-        showUpLeftHeartAnimator = getAnimatorFromResource(R.animator.animator_show_up,
-            component.hearts[0]).apply {
-            startDelay = 180L
-            addListener(object : AnimatorListenerAdapter() {
-                override fun onAnimationEnd(animation: Animator?) {
-                    super.onAnimationEnd(animation)
-                    showUpLeftHeartAnimator.removeAllListeners()
-                }
-            })
-        }
-        showUpRightHeartAnimator = getAnimatorFromResource(R.animator.animator_show_up,
-            component.hearts[1]).apply {
-            startDelay = 180L
-            addListener(object : AnimatorListenerAdapter() {
-                override fun onAnimationEnd(animation: Animator?) {
-                    super.onAnimationEnd(animation)
-                    showUpRightHeartAnimator.removeAllListeners()
-                }
-            })
-        }
-        showBigHeartAnimator = getAnimatorFromResource(R.animator.animator_show_big_heart,
-            component.face.ivHomeBigHeart).apply {
-            addListener(object : AnimatorListenerAdapter() {
-                override fun onAnimationEnd(animation: Animator?) {
-                    super.onAnimationEnd(animation)
-                    showBigHeartAnimator.removeAllListeners()
-                }
-            })
-        }
+        showLeftEyeHeartAnimator =
+            getAnimatorFromResource(
+                R.animator.animator_show_up, component.face.ivHomeSnowmanLeftEyeHeartLv4
+            ).apply {
+                startDelay = 180L
+            }
 
-        showLeftEyeHeartAnimator = getAnimatorFromResource(R.animator.animator_show_up,
-            component.face.ivHomeSnowmanLeftEyeHeartLv4).apply {
-            startDelay = 180L
-            addListener(object : AnimatorListenerAdapter() {
-                override fun onAnimationEnd(animation: Animator?) {
-                    super.onAnimationEnd(animation)
-                    showLeftEyeHeartAnimator.removeAllListeners()
-                }
-            })
-        }
+        showRightEyeHeartAnimator =
+            getAnimatorFromResource(
+                R.animator.animator_show_up, component.face.ivHomeSnowmanRightEyeHeartLv4
+            ).apply {
+                startDelay = 180L
+            }
 
-        showRightEyeHeartAnimator = getAnimatorFromResource(R.animator.animator_show_up,
-            component.face.ivHomeSnowmanRightEyeHeartLv4).apply {
-            startDelay = 180L
-            addListener(object : AnimatorListenerAdapter() {
-                override fun onAnimationEnd(animation: Animator?) {
-                    super.onAnimationEnd(animation)
-                    showRightEyeHeartAnimator.removeAllListeners()
-                }
-            })
-        }
+        disappearFirstExclamationAnimator =
+            getAnimatorFromResource(R.animator.animator_disappear, component.exclamations[0])
 
-        disappearFirstExclamationAnimator = getAnimatorFromResource(R.animator.animator_disappear,
-            component.exclamations[0]).apply {
-            addListener(object : AnimatorListenerAdapter() {
-                override fun onAnimationEnd(animation: Animator?) {
-                    super.onAnimationEnd(animation)
-                    disappearFirstExclamationAnimator.removeAllListeners()
-                }
-            })
-        }
-
-        disappearSecondExclamationAnimator = getAnimatorFromResource(R.animator.animator_disappear,
-            component.exclamations[1]).apply {
-            addListener(object : AnimatorListenerAdapter() {
-                override fun onAnimationEnd(animation: Animator?) {
-                    super.onAnimationEnd(animation)
-                    disappearSecondExclamationAnimator.removeAllListeners()
-                }
-            })
-        }
+        disappearSecondExclamationAnimator =
+            getAnimatorFromResource(R.animator.animator_disappear, component.exclamations[1])
     }
 
     private fun setEyesInvisible() {
@@ -302,10 +253,12 @@ class SnowmanLv4Animator(
         val moveRightEyePropertyY = PropertyValuesHolder.ofFloat(View.TRANSLATION_Y,
             rightBlackEyeInfo.height - rightWhiteEyeInfo.height - (rightWhiteEyeInfo.y - rightBlackEyeInfo.y))
         moveRightEyeToLeftAnimator =
-            getAnimatorFromProperties(component.face.ivHomeSnowmanRightEyeWhiteLv4,
+            getAnimatorFromProperties(
+                component.face.ivHomeSnowmanRightEyeWhiteLv4,
                 moveRightEyePropertyX,
                 moveRightEyePropertyY,
-                600)
+                600
+            )
     }
 
     private fun getAnimatorFromProperties(

--- a/app/src/main/java/com/ariari/mowoori/ui/missionsadd/MissionsAddFragment.kt
+++ b/app/src/main/java/com/ariari/mowoori/ui/missionsadd/MissionsAddFragment.kt
@@ -158,7 +158,7 @@ class MissionsAddFragment :
 
     private fun isMissionNameValid(): Boolean {
         with(binding.tvMissionsAddWhatInvalid) {
-            return@isMissionNameValid if (binding.etMissionsAddWhat.text.length !in 1..10) {
+            return@isMissionNameValid if (binding.etMissionsAddWhat.text.length !in 1..15) {
                 isVisible = true
                 getVibrateAnimInstance().run {
                     setTarget(binding.tvMissionsAddWhatInvalid)

--- a/app/src/main/res/layout/fragment_missions_add.xml
+++ b/app/src/main/res/layout/fragment_missions_add.xml
@@ -43,11 +43,11 @@
 
         <EditText
             android:id="@+id/et_missions_add_what"
-            android:layout_width="wrap_content"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginStart="16dp"
             android:layout_marginTop="4dp"
-            android:layout_marginEnd="16dp"
+            android:layout_marginEnd="80dp"
             android:autofillHints="no"
             android:cursorVisible="false"
             android:focusable="true"
@@ -56,6 +56,7 @@
             android:inputType="textNoSuggestions"
             android:textColor="@color/sky_blue_2094FF"
             android:textSize="22sp"
+            app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/tv_missions_add_what_title" />
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -87,7 +87,7 @@
     <string name="missions_add_count_front">미션을</string>
     <string name="missions_add_count_back">번 수행할거예요.</string>
     <string name="missions_add_when_start">부터</string>
-    <string name="missions_add_what_invalid">1~10자 사이로 입력해주세요.</string>
+    <string name="missions_add_what_invalid">1~15자 사이로 입력해주세요.</string>
     <string name="missions_add_when_start_title">시작일</string>
     <string name="missions_add_when_start_hint">2021년 10월 11일</string>
     <string name="missions_add_when_end_title">종료일</string>


### PR DESCRIPTION
# ❗️ 이슈 트래킹
- #74 
- #23 

# 💡 작업목록
- 그룹 이동 시 애니메이터 리스너 삭제 위치 수정
- 미션 생성 - 미션 이름 제한 글자 수정

# ❓ 고민과 해결
- 다른 그룹으로 이동시 4단계 애니메이션이 중간에서 끊기는 문제가 있었다.
- 리스너 문제인 것 같긴한데 왜그러나 하다가 초기화 문제인가보다 하고 초기화 위치를 수정해주니까 잘 작동되기는 했다. 하지만 로그를 찍어보니 초기화 문제는 아니었다. 그럼 무슨 문제인가... 그룹 이동 시 애니메이터 리스너들을 다 삭제해주는데 애니메이터가 초기화되고 리스너가 추가되는 동작이 실행된 이후에 리스너들을 삭제하는 동작을 해서 이미 초기화됐던 리스너들이 삭제되었던 것이다... 리스너 삭제 위치를 수정해주니 해결되었다!
<img width="1114" alt="스크린샷 2021-11-18 오후 6 24 30" src="https://user-images.githubusercontent.com/68374234/142392391-9f685a3f-d797-497e-ad5f-cf3d6c92e624.png">

