### PR TITLE
[13-1] 스탬프 리사이클러뷰 스크롤 시 갱신 문제 해결 및 인증하기 완료 중이라는 로딩화면 추가

### DIFF
--- a/app/src/main/java/com/ariari/mowoori/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/com/ariari/mowoori/ui/home/HomeViewModel.kt
@@ -84,7 +84,7 @@ class HomeViewModel @Inject constructor(
 
     fun setCurrentGroupInfo(groupId: String) {
         val currGroupList = groupList.value ?: return
-        val tempGroupList = currGroupList.toMutableList().map {
+        val tempGroupList = currGroupList.map {
             val copyGroup = it.copy()
             copyGroup.selected = copyGroup.groupId == groupId
             if (copyGroup.selected) _currentGroupInfo.value = it

--- a/app/src/main/java/com/ariari/mowoori/ui/stamp/adapter/StampsAdapter.kt
+++ b/app/src/main/java/com/ariari/mowoori/ui/stamp/adapter/StampsAdapter.kt
@@ -56,8 +56,6 @@ class StampsAdapter(private val listener: OnItemClickListener) :
                         .circleCrop()
                         .into(binding.ivItemStamps)
 
-//                    binding.ivItemStamps.setImageResource(R.drawable.ic_launcher_background)
-//                    binding.ivItemStamps.clipToOutline = true
                     binding.tvItemStampsIndex.isInvisible = true
                     binding.containerItemStamps.isClickable = true
                 }
@@ -72,6 +70,7 @@ class StampsAdapter(private val listener: OnItemClickListener) :
                     binding.containerItemStamps.isClickable = true
                 }
                 else -> {
+                    binding.ivItemStamps.setImageResource(R.drawable.border_sky_blue_line_oval)
                     binding.tvItemStampsIndex.isVisible = true
                     binding.containerItemStamps.isClickable = false
                 }

--- a/app/src/main/java/com/ariari/mowoori/ui/stamp_detail/StampDetailFragment.kt
+++ b/app/src/main/java/com/ariari/mowoori/ui/stamp_detail/StampDetailFragment.kt
@@ -27,6 +27,7 @@ import com.ariari.mowoori.util.LogUtil
 import com.ariari.mowoori.util.getCurrentDateTime
 import com.ariari.mowoori.util.toastMessage
 import com.ariari.mowoori.widget.PictureDialogFragment
+import com.ariari.mowoori.widget.ProgressDialogManager
 import com.bumptech.glide.Glide
 import com.bumptech.glide.load.resource.bitmap.CenterCrop
 import com.bumptech.glide.load.resource.bitmap.RoundedCorners
@@ -37,7 +38,7 @@ import java.io.File
 @AndroidEntryPoint
 class StampDetailFragment :
     BaseFragment<FragmentStampDetailBinding>(R.layout.fragment_stamp_detail) {
-    private val viewModel: StampDetailViewModel by viewModels()
+    private val stampViewModel: StampDetailViewModel by viewModels()
     private val safeArgs: StampDetailFragmentArgs by navArgs()
     private lateinit var detailInfo: DetailInfo
 
@@ -75,7 +76,7 @@ class StampDetailFragment :
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         binding.lifecycleOwner = viewLifecycleOwner
-        binding.viewModel = viewModel
+        binding.viewModel = stampViewModel
         init()
         setListener()
         setObserver()
@@ -99,6 +100,7 @@ class StampDetailFragment :
     }
 
     private fun setObserver() {
+        setLoadingObserver()
         setIsMissionPostedObserver()
         setCloseBtnClickObserver()
         setIsCertifyObserver()
@@ -116,7 +118,7 @@ class StampDetailFragment :
     }
 
     private fun setBtnVisible() {
-        viewModel.setIsCertify(detailInfo.detailMode)
+        stampViewModel.setIsCertify(detailInfo.detailMode)
     }
 
     private fun setDetailTransitionName() {
@@ -124,19 +126,19 @@ class StampDetailFragment :
     }
 
     private fun setUserName() {
-        viewModel.setUserName(detailInfo.userName)
+        stampViewModel.setUserName(detailInfo.userName)
     }
 
     private fun setMissionId() {
-        viewModel.setMissionId(detailInfo.missionId)
+        stampViewModel.setMissionId(detailInfo.missionId)
     }
 
     private fun setMissionName() {
-        viewModel.setMissionName(detailInfo.missionName)
+        stampViewModel.setMissionName(detailInfo.missionName)
     }
 
     private fun setComment() {
-        viewModel.setComment(detailInfo.stampInfo.comment)
+        stampViewModel.setComment(detailInfo.stampInfo.comment)
     }
 
     private fun setPictureClickListener() {
@@ -159,8 +161,8 @@ class StampDetailFragment :
 
     private fun setBtnCertifyListener() {
         binding.btnStampDetailCertify.setOnClickListener {
-            viewModel.setComment(binding.etStampDetailComment.text.toString())
-            viewModel.postStamp()
+            stampViewModel.setComment(binding.etStampDetailComment.text.toString())
+            stampViewModel.postStamp()
         }
     }
 
@@ -227,7 +229,7 @@ class StampDetailFragment :
     }
 
     private fun saveCurrentPicture(uri: Uri?) {
-        viewModel.setPictureUri(uri)
+        stampViewModel.setPictureUri(uri)
         Glide.with(requireContext())
             .load(uri)
             .override(300, 300)
@@ -262,13 +264,13 @@ class StampDetailFragment :
     }
 
     private fun setCloseBtnClickObserver() {
-        viewModel.closeBtnClick.observe(viewLifecycleOwner, EventObserver {
+        stampViewModel.closeBtnClick.observe(viewLifecycleOwner, EventObserver {
             this.findNavController().popBackStack()
         })
     }
 
     private fun setIsCertifyObserver() {
-        viewModel.isCertify.observe(viewLifecycleOwner, EventObserver {
+        stampViewModel.isCertify.observe(viewLifecycleOwner, EventObserver {
             if (it) {
                 binding.btnStampDetailCertify.isVisible = true
                 binding.tvStampDetailComment.isFocusable = true
@@ -280,15 +282,22 @@ class StampDetailFragment :
     }
 
     private fun setCommentObserver() {
-        viewModel.comment.observe(viewLifecycleOwner) {
+        stampViewModel.comment.observe(viewLifecycleOwner) {
             binding.etStampDetailComment.setText(it)
         }
     }
 
     private fun setIsMissionPostedObserver() {
-        viewModel.isStampPosted.observe(viewLifecycleOwner, EventObserver {
+        stampViewModel.isStampPosted.observe(viewLifecycleOwner, EventObserver {
             // TODO: 알림 발생
             this.findNavController().popBackStack()
+        })
+    }
+
+    private fun setLoadingObserver() {
+        stampViewModel.loadingEvent.observe(viewLifecycleOwner, EventObserver { isLoading ->
+            if (isLoading) ProgressDialogManager.instance.show(requireContext())
+            else ProgressDialogManager.instance.clear()
         })
     }
 }

--- a/app/src/main/java/com/ariari/mowoori/ui/stamp_detail/StampDetailViewModel.kt
+++ b/app/src/main/java/com/ariari/mowoori/ui/stamp_detail/StampDetailViewModel.kt
@@ -22,6 +22,9 @@ import javax.inject.Inject
 class StampDetailViewModel @Inject constructor(
     private val stampsRepository: StampsRepository
 ) : ViewModel() {
+    private val _loadingEvent = MutableLiveData<Event<Boolean>>()
+    val loadingEvent: LiveData<Event<Boolean>> get() = _loadingEvent
+
     private val _closeBtnClick = MutableLiveData<Event<Boolean>>()
     val closeBtnClick: LiveData<Event<Boolean>> get() = _closeBtnClick
 
@@ -45,6 +48,10 @@ class StampDetailViewModel @Inject constructor(
 
     private val _isStampPosted = MutableLiveData<Event<Unit>>()
     val isStampPosted: LiveData<Event<Unit>> get() = _isStampPosted
+
+    fun setLoadingEvent(flag: Boolean) {
+        _loadingEvent.postValue(Event(flag))
+    }
 
     fun setCloseBtnClick() {
         _closeBtnClick.value = Event(true)
@@ -81,6 +88,7 @@ class StampDetailViewModel @Inject constructor(
     }
 
     fun postStamp() {
+        setLoadingEvent(true)
         viewModelScope.launch(IO) {
             stampsRepository.putCertificationImage(pictureUri.value!!, missionId.value!!)
                 .onSuccess { uri ->
@@ -94,6 +102,7 @@ class StampDetailViewModel @Inject constructor(
                             stampsRepository.postStamp(stampInfo, Mission(missionId.value!!, it))
                                 .onSuccess {
                                     _isStampPosted.postValue(Event(Unit))
+                                    setLoadingEvent(false)
                                 }.onFailure {
                                     throw Exception("stampInfo is not Posted.")
                                 }

--- a/app/src/main/java/com/ariari/mowoori/ui/stamp_detail/StampDetailViewModel.kt
+++ b/app/src/main/java/com/ariari/mowoori/ui/stamp_detail/StampDetailViewModel.kt
@@ -11,6 +11,7 @@ import com.ariari.mowoori.ui.missions.entity.Mission
 import com.ariari.mowoori.ui.stamp.entity.DetailMode
 import com.ariari.mowoori.ui.stamp.entity.StampInfo
 import com.ariari.mowoori.util.Event
+import com.ariari.mowoori.util.LogUtil
 import com.ariari.mowoori.util.getCurrentDate
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Dispatchers.IO
@@ -83,6 +84,7 @@ class StampDetailViewModel @Inject constructor(
         viewModelScope.launch(IO) {
             stampsRepository.putCertificationImage(pictureUri.value!!, missionId.value!!)
                 .onSuccess { uri ->
+                    LogUtil.log("stamp",uri)
                     stampsRepository.getMissionInfo(missionId.value!!.toString())
                         .onSuccess {
                             val stampInfo = StampInfo(

--- a/app/src/main/res/layout/item_stamps.xml
+++ b/app/src/main/res/layout/item_stamps.xml
@@ -17,13 +17,13 @@
             android:layout_width="@dimen/stamp_width"
             android:layout_height="@dimen/stamp_height"
             android:layout_margin="4dp"
-            android:background="@drawable/border_sky_blue_line_oval"
+            android:background="@android:color/transparent"
             android:contentDescription="@string/desc_item_stamps_stamp"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent"
-            tools:src="@drawable/ic_launcher_background" />
+            tools:src="@drawable/ic_empty" />
 
         <TextView
             android:id="@+id/tv_item_stamps_index"


### PR DESCRIPTION
# ❗️ 이슈 트래킹
- #24 

# 💡 작업목록
- 스탬프 리사이클러뷰 스크롤 시 갱신 문제 해결
- 미션 인증 시, 인증하기 버튼 여러번 누르지 못하도록 + 인증하기 완료 중이라는 로딩 뷰 추가

# ❓ 고민과 해결
- 스탬프 찍을 때 (미션인증) 오래걸리는 이유 : 인증 사진을 Firebase Storage에 올리고 난 후 이 동작이 성공하면 url을 가져오는데 올리는 동작이 오래걸린다. url을 갖고 오고 나서 Firebase Realtime Database를 갱신하는 부분은 매우 빠르다...
  - 일단 오래걸리는 동안 인증하기를 다시 터치하지 못하도록 로딩뷰를 추가했는데 이미지 업로드 부분이 느린 것을 해결할 방법을 찾아봐야겠다..
  - 이미지가 올라가는 동안 일단 스탬프는 비어있는 url과 함께 post하고 나중에 성공하면 url을 갱신하던가.. (이때 사용자의 폰에 띄워야하는 이미지는 기기 내부 위치를 담고있는 uri를 통해 띄울 수 있다.)

