### PR TITLE
[fix-1] 인증 완료 시 스탬프 숫자 밀리는 버그 해결

### DIFF
--- a/app/src/main/java/com/ariari/mowoori/ui/stamp/StampsViewModel.kt
+++ b/app/src/main/java/com/ariari/mowoori/ui/stamp/StampsViewModel.kt
@@ -44,9 +44,6 @@ class StampsViewModel @Inject constructor(
     private val _isMyMission = MutableLiveData<Event<Boolean>>()
     val isMyMission: LiveData<Event<Boolean>> get() = _isMyMission
 
-    private val _user = MutableLiveData<User>()
-    val user: LiveData<User> get() = _user
-
     fun setLoadingEvent(flag: Boolean) {
         _loadingEvent.postValue(Event(flag))
     }
@@ -85,7 +82,6 @@ class StampsViewModel @Inject constructor(
     }
 
     fun setIsMyMission(userId: String) {
-        LogUtil.log("setIsMyMission", user.value?.userId.toString())
         stampsRepository.getUserId()
             .onSuccess { uid ->
                 _isMyMission.value = Event(uid == userId)
@@ -101,6 +97,7 @@ class StampsViewModel @Inject constructor(
                 .onSuccess {
                     _mission.postValue(Mission(missionId, it))
                 }.onFailure {
+                    // TODO: 네트워크 연결 끊김 처리
                     Timber.e("$it")
                 }
         }

--- a/app/src/main/java/com/ariari/mowoori/ui/stamp/StampsViewModel.kt
+++ b/app/src/main/java/com/ariari/mowoori/ui/stamp/StampsViewModel.kt
@@ -3,10 +3,12 @@ package com.ariari.mowoori.ui.stamp
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.switchMap
 import androidx.lifecycle.viewModelScope
 import com.ariari.mowoori.data.repository.MissionsRepository
 import com.ariari.mowoori.data.repository.StampsRepository
 import com.ariari.mowoori.ui.missions.entity.Mission
+import com.ariari.mowoori.ui.missions.entity.MissionInfo
 import com.ariari.mowoori.ui.register.entity.User
 import com.ariari.mowoori.ui.stamp.entity.Stamp
 import com.ariari.mowoori.ui.stamp.entity.StampInfo
@@ -21,7 +23,7 @@ import javax.inject.Inject
 @HiltViewModel
 class StampsViewModel @Inject constructor(
     private val stampsRepository: StampsRepository,
-    private val missionsRepository: MissionsRepository
+    private val missionsRepository: MissionsRepository,
 ) : ViewModel() {
 
     private val _loadingEvent = MutableLiveData<Event<Boolean>>()
@@ -36,14 +38,8 @@ class StampsViewModel @Inject constructor(
     private val _mission = MutableLiveData<Mission>()
     val mission: LiveData<Mission> get() = _mission
 
-    private val _stampList = MutableLiveData<MutableList<Stamp>>()
-    val stampList: LiveData<MutableList<Stamp>> get() = _stampList
-
-    private val _curStampList = MutableLiveData<MutableList<Stamp>>()
-    val curStampList: LiveData<MutableList<Stamp>> get() = _curStampList
-
-    private val _selectedStampInfo = MutableLiveData<Event<StampInfo>>()
-    val selectedStampInfo: LiveData<Event<StampInfo>> get() = _selectedStampInfo
+    val stampList: LiveData<Event<MutableList<Stamp>>> =
+        mission.switchMap { getAllStamps(it.missionInfo) }
 
     private val _isMyMission = MutableLiveData<Event<Boolean>>()
     val isMyMission: LiveData<Event<Boolean>> get() = _isMyMission
@@ -63,19 +59,11 @@ class StampsViewModel @Inject constructor(
         _backBtnClick.value = Event(true)
     }
 
-//    fun setAllEmptyStamps(totalStamp: Int) {
-//        val tempEmptyStampList = mutableListOf<Stamp>()
-//        repeat(totalStamp) {
-//            tempEmptyStampList.add(Stamp(stampInfo = StampInfo()))
-//        }
-//        _stampList.value = tempEmptyStampList
-//    }
-
-    fun setStampList() {
-        // postValue 이슈 방지를 위해 for 문 밖에서 스코프 설정
+    private fun getAllStamps(missionInfo: MissionInfo): LiveData<Event<MutableList<Stamp>>> {
+        val tempMutableLiveData = MutableLiveData<Event<MutableList<Stamp>>>()
         viewModelScope.launch(Dispatchers.IO) {
             val tempStampList = mutableListOf<Stamp>()
-            mission.value?.missionInfo?.stampList?.forEach { stampId ->
+            missionInfo.stampList.forEach { stampId ->
                 stampsRepository.getStampInfo(stampId)
                     .onSuccess { stampInfo ->
                         tempStampList.add(Stamp(stampId, stampInfo))
@@ -84,52 +72,37 @@ class StampsViewModel @Inject constructor(
                         Timber.e("stampInfo Error: $it")
                     }
             }
-            _curStampList.postValue(tempStampList)
-            setLoadingEvent(false)
+            tempStampList.addAll(createEmptyStamps(missionInfo.totalStamp - tempStampList.size))
+            tempMutableLiveData.postValue(Event(tempStampList))
         }
+        return tempMutableLiveData
     }
 
-    fun fillEmptyStamps(count: Int) {
-        if (count == 0) return
-
-        curStampList.value?.let {
-            val tempEmptyStampList = it.toMutableList()
-            repeat(count) {
-                tempEmptyStampList.add(Stamp(stampInfo = StampInfo()))
-            }
-            _stampList.value = tempEmptyStampList
-        }
+    private fun createEmptyStamps(count: Int): MutableList<Stamp> {
+        val tempStampList = mutableListOf<Stamp>()
+        repeat(count) { tempStampList.add(Stamp(stampInfo = StampInfo())) }
+        return tempStampList
     }
 
-    fun setSelectedStampInfo(position: Int, currentStamp: Int) {
-        if (position >= currentStamp) return
-        _selectedStampInfo.value = Event(_stampList.value?.get(position)?.stampInfo!!)
-    }
-
-    fun setIsMyMission() {
+    fun setIsMyMission(userId: String) {
         LogUtil.log("setIsMyMission", user.value?.userId.toString())
         stampsRepository.getUserId()
             .onSuccess { uid ->
-                _isMyMission.value = Event(uid == user.value!!.userId)
+                _isMyMission.value = Event(uid == userId)
             }
             .onFailure {
-                Timber.e("${it.message}")
+                Timber.e("$it")
             }
     }
 
     fun loadMissionInfo(missionId: String) {
         viewModelScope.launch {
-            LogUtil.log("missionId - loadMission", missionId)
-            missionsRepository.getMissionInfo(missionId).onSuccess {
-                _mission.postValue(Mission(missionId, it))
-            }.onFailure {
-                Timber.e("$it")
-            }
+            missionsRepository.getMissionInfo(missionId)
+                .onSuccess {
+                    _mission.postValue(Mission(missionId, it))
+                }.onFailure {
+                    Timber.e("$it")
+                }
         }
-    }
-
-    fun setUser(user: User) {
-        _user.postValue(user)
-        LogUtil.log("setUser", user.toString())
     }
 }


### PR DESCRIPTION
# ❗️ 이슈 트래킹
- #102 

# 💡 작업목록
- 인증 완료 시 스탬프 숫자 밀리는 버그 해결

# ❓ 고민과 해결
- popBackStack() 을 통해 프래그먼트에 접근을 하면 라이브데이터 값이 변경되지 않아도 변경이 감지되어 쓸데없이 해당 옵저버 코드가 실행이 된다. -> 라이브데이터의 타입을 Event 로 감싼 타입으로 변경

