### PR TITLE
[14-2] FCM 푸쉬 알림 수신 구현

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -68,6 +68,8 @@ dependencies {
     implementation 'com.google.firebase:firebase-database-ktx'
     implementation 'com.google.firebase:firebase-storage-ktx'
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-play-services:$coroutinePlayServices"
+    implementation 'com.google.firebase:firebase-messaging-ktx'
+    implementation 'com.google.firebase:firebase-analytics-ktx'
 
     // Glide
     implementation "com.github.bumptech.glide:glide:$glideVersion"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -43,6 +43,15 @@
                 android:name="android.support.FILE_PROVIDER_PATHS"
                 android:resource="@xml/file_paths"/>
         </provider>
+
+        <service
+            android:name="com.ariari.mowoori.util.MowooriMessagingService"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="com.google.firebase.MESSAGING_EVENT" />
+            </intent-filter>
+        </service>
+
     </application>
 
 </manifest>

--- a/app/src/main/java/com/ariari/mowoori/data/repository/IntroRepository.kt
+++ b/app/src/main/java/com/ariari/mowoori/data/repository/IntroRepository.kt
@@ -13,4 +13,6 @@ interface IntroRepository {
     suspend fun userRegister(userInfo: UserInfo): Boolean
 
     suspend fun putUserProfile(uri: Uri): String
+
+    suspend fun updateFcmToken(token:String)
 }

--- a/app/src/main/java/com/ariari/mowoori/data/repository/IntroRepositoryImpl.kt
+++ b/app/src/main/java/com/ariari/mowoori/data/repository/IntroRepositoryImpl.kt
@@ -47,4 +47,8 @@ class IntroRepositoryImpl @Inject constructor(
         val uploadUrl = task.storage.downloadUrl.await()
         return uploadUrl.toString()
     }
+
+    override suspend fun updateFcmToken(token: String) {
+        firebaseReference.child("users/${getUserUid()}/fcmToken").setValue(token)
+    }
 }

--- a/app/src/main/java/com/ariari/mowoori/ui/intro/IntroViewModel.kt
+++ b/app/src/main/java/com/ariari/mowoori/ui/intro/IntroViewModel.kt
@@ -6,6 +6,8 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.ariari.mowoori.data.repository.IntroRepository
 import com.ariari.mowoori.util.Event
+import com.google.android.gms.tasks.OnCompleteListener
+import com.google.firebase.messaging.FirebaseMessaging
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -18,10 +20,27 @@ class IntroViewModel @Inject constructor(
     private val _isUserRegistered = MutableLiveData<Event<Boolean>>()
     val isUserRegistered: LiveData<Event<Boolean>> = _isUserRegistered
 
+    private var fcmToken = ""
+
+
     fun checkUserRegistered(userUid: String) {
         viewModelScope.launch(Dispatchers.IO) {
             val isRegistered = introRepository.checkUserRegistered(userUid)
             _isUserRegistered.postValue(Event(isRegistered))
         }
     }
+
+    fun initFcmToken() {
+        FirebaseMessaging.getInstance().token.addOnCompleteListener(OnCompleteListener { task ->
+            if (!task.isSuccessful) {
+                return@OnCompleteListener
+            }
+            fcmToken = task.result.toString()
+        })
+    }
+
+    fun updateFcmToken() {
+        viewModelScope.launch(Dispatchers.IO) { introRepository.updateFcmToken(fcmToken) }
+    }
+
 }

--- a/app/src/main/java/com/ariari/mowoori/ui/register/RegisterActivity.kt
+++ b/app/src/main/java/com/ariari/mowoori/ui/register/RegisterActivity.kt
@@ -45,6 +45,7 @@ class RegisterActivity : AppCompatActivity() {
         setRootClick()
         setCompleteClick()
         viewModel.createNickName()
+        viewModel.initFcmToken()
     }
 
     private fun setObservers() {

--- a/app/src/main/java/com/ariari/mowoori/ui/register/RegisterViewModel.kt
+++ b/app/src/main/java/com/ariari/mowoori/ui/register/RegisterViewModel.kt
@@ -8,6 +8,8 @@ import androidx.lifecycle.viewModelScope
 import com.ariari.mowoori.data.repository.IntroRepository
 import com.ariari.mowoori.ui.register.entity.UserInfo
 import com.ariari.mowoori.util.Event
+import com.google.android.gms.tasks.OnCompleteListener
+import com.google.firebase.messaging.FirebaseMessaging
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -29,6 +31,8 @@ class RegisterViewModel @Inject constructor(
 
     private val _profileImageUri = MutableLiveData<Uri>()
     val profileImageUri: LiveData<Uri> = _profileImageUri
+
+    private var fcmToken = ""
 
     private val _loadingEvent = MutableLiveData<Event<Boolean>>()
     val loadingEvent: LiveData<Event<Boolean>> = _loadingEvent
@@ -63,11 +67,21 @@ class RegisterViewModel @Inject constructor(
             val success = introRepository.userRegister(
                 UserInfo(
                     nickname = nickname,
-                    profileImage = uploadUrl
+                    profileImage = uploadUrl,
+                    fcmToken = fcmToken
                 )
             )
             _registerSuccessEvent.postValue(Event(success))
         }
+    }
+
+    fun initFcmToken() {
+        FirebaseMessaging.getInstance().token.addOnCompleteListener(OnCompleteListener { task ->
+            if (!task.isSuccessful) {
+                return@OnCompleteListener
+            }
+            fcmToken = task.result.toString()
+        })
     }
 
     private fun checkNicknameValid(nickname: String): Boolean {

--- a/app/src/main/java/com/ariari/mowoori/ui/register/entity/User.kt
+++ b/app/src/main/java/com/ariari/mowoori/ui/register/entity/User.kt
@@ -13,6 +13,7 @@ data class User(
 data class UserInfo(
     val nickname: String = "",
     val profileImage: String = "",
+    val fcmToken: String = "",
     val groupList: List<String> = emptyList(),
     val currentGroupId: String = ""
 ) : Parcelable

--- a/app/src/main/java/com/ariari/mowoori/util/MowooriMessagingService.kt
+++ b/app/src/main/java/com/ariari/mowoori/util/MowooriMessagingService.kt
@@ -1,0 +1,60 @@
+package com.ariari.mowoori.util
+
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import android.os.Build
+import androidx.core.app.NotificationCompat
+import com.ariari.mowoori.R
+import com.ariari.mowoori.ui.main.MainActivity
+import com.google.firebase.messaging.FirebaseMessagingService
+import com.google.firebase.messaging.RemoteMessage
+
+class MowooriMessagingService : FirebaseMessagingService() {
+    override fun onNewToken(token: String) {
+        super.onNewToken(token)
+    }
+
+    override fun onMessageReceived(remoteMessage: RemoteMessage) {
+        super.onMessageReceived(remoteMessage)
+        if (remoteMessage.data.isNotEmpty()) {
+            notifyFcm(remoteMessage)
+        }
+
+    }
+
+    private fun notifyFcm(remoteMessage: RemoteMessage) {
+        val alarmId = remoteMessage.sentTime.toInt()
+        val intent = Intent(this, MainActivity::class.java)
+        intent.putExtra("openFromFcm", true)
+        intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP)
+        val pendingIntent =
+            PendingIntent.getActivity(this, FLOAT_NOTIFICATION, intent, PendingIntent.FLAG_ONE_SHOT)
+        val builder =
+            NotificationCompat.Builder(this, getString(R.string.app_name))
+                .setContentTitle(remoteMessage.data["title"])
+                .setContentText(remoteMessage.data["body"])
+                .setSmallIcon(R.mipmap.ic_app_logo)
+                .setContentIntent(pendingIntent)
+                .setPriority(NotificationCompat.PRIORITY_MAX)
+                .setAutoCancel(true)
+        val notificationManager =
+            getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val channelId = getString(R.string.app_name)
+            val channelName = getString(R.string.app_name)
+            val channelImportance = NotificationManager.IMPORTANCE_HIGH
+            val channel = NotificationChannel(channelId, channelName, channelImportance)
+            notificationManager.createNotificationChannel(channel)
+        }
+
+        notificationManager.notify(alarmId, builder.build())
+    }
+
+    companion object {
+        const val FLOAT_NOTIFICATION = 0
+    }
+}


### PR DESCRIPTION
# ❗️ 이슈 트래킹
- #27 

# 💡 작업목록
- gradle에 FCM 설정 추가
- Manifestdp FirebaseMessagingService 확장하는 서비스 추가
- MowooriMessagingService에 FCM 받았을 시 동작 구현
- 유저 회원가입 시 fcmToken userInfo로 함께 등록
- 유저 로그인 시 마다 fcmToken 갱신

# ❓ 고민과 해결
- 서버가 없어서 FCM을 어디서 보내야할지 고민이었고, 클라이언트에서 서버키를 가지고 post를 할까 생각도 했지만 클라이언트에 서버키를 갖고있는 것은 위험하다고 생각했고, realtimeDatabase와 함께 쓰는 functions으로 구현해볼 생각이다.

