### PR TITLE
[14-2] FCM 푸쉬 알림 수신 및 클라이언트에서 FCM post 요청 보내기 버튼으로 임시 구현

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -68,6 +68,8 @@ dependencies {
     implementation 'com.google.firebase:firebase-database-ktx'
     implementation 'com.google.firebase:firebase-storage-ktx'
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-play-services:$coroutinePlayServices"
+    implementation 'com.google.firebase:firebase-messaging-ktx'
+    implementation 'com.google.firebase:firebase-analytics-ktx'
 
     // Glide
     implementation "com.github.bumptech.glide:glide:$glideVersion"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -87,4 +87,7 @@ dependencies {
 
     // Gson
     implementation "com.google.code.gson:gson:$gsonVersion"
+
+    // EncryptedSharedPreferences
+    implementation "androidx.security:security-crypto:1.1.0-alpha03"
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -90,4 +90,8 @@ dependencies {
 
     // EncryptedSharedPreferences
     implementation "androidx.security:security-crypto:1.1.0-alpha03"
+
+    // Retrofit
+    implementation 'com.squareup.retrofit2:retrofit:2.9.0'
+    implementation 'com.squareup.retrofit2:converter-gson:2.9.0'
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -43,6 +43,15 @@
                 android:name="android.support.FILE_PROVIDER_PATHS"
                 android:resource="@xml/file_paths"/>
         </provider>
+
+        <service
+            android:name="com.ariari.mowoori.util.MowooriMessagingService"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="com.google.firebase.MESSAGING_EVENT" />
+            </intent-filter>
+        </service>
+
     </application>
 
 </manifest>

--- a/app/src/main/java/com/ariari/mowoori/data/local/datasource/MoWooriPrefDataSource.kt
+++ b/app/src/main/java/com/ariari/mowoori/data/local/datasource/MoWooriPrefDataSource.kt
@@ -1,6 +1,6 @@
-package com.ariari.mowoori.data.preference
+package com.ariari.mowoori.data.local.datasource
 
-interface MoWooriPreference {
+interface MoWooriPrefDataSource {
     fun getUserRegistered(): Boolean
     fun setUserRegistered(boolean: Boolean)
 }

--- a/app/src/main/java/com/ariari/mowoori/data/local/datasource/MoWooriPrefDataSourceImpl.kt
+++ b/app/src/main/java/com/ariari/mowoori/data/local/datasource/MoWooriPrefDataSourceImpl.kt
@@ -1,16 +1,16 @@
-package com.ariari.mowoori.data.preference
+package com.ariari.mowoori.data.local.datasource
 
 import android.content.SharedPreferences
 import javax.inject.Inject
 
-class MoWooriPreferenceImpl @Inject constructor(
+class MoWooriPrefDataSourceImpl @Inject constructor(
     private val prefs: SharedPreferences
-) : MoWooriPreference {
+) : MoWooriPrefDataSource {
 
     override fun getUserRegistered(): Boolean = prefs.getBoolean(USER_REGISTERED_KEY, false)
+
     override fun setUserRegistered(boolean: Boolean) =
         prefs.edit().putBoolean(USER_REGISTERED_KEY, boolean).apply()
-
 
     companion object {
         private const val USER_REGISTERED_KEY = "USER_REGISTERED"

--- a/app/src/main/java/com/ariari/mowoori/data/remote/datasource/FcmDataSource.kt
+++ b/app/src/main/java/com/ariari/mowoori/data/remote/datasource/FcmDataSource.kt
@@ -1,5 +1,8 @@
 package com.ariari.mowoori.data.remote.datasource
 
-interface FcmDataSource {
+import com.ariari.mowoori.data.remote.request.FcmRequest
+import com.ariari.mowoori.data.remote.response.FcmResponse
 
+interface FcmDataSource {
+    suspend fun postFcmMessage(body:FcmRequest):FcmResponse
 }

--- a/app/src/main/java/com/ariari/mowoori/data/remote/datasource/FcmDataSource.kt
+++ b/app/src/main/java/com/ariari/mowoori/data/remote/datasource/FcmDataSource.kt
@@ -1,0 +1,5 @@
+package com.ariari.mowoori.data.remote.datasource
+
+interface FcmDataSource {
+
+}

--- a/app/src/main/java/com/ariari/mowoori/data/remote/datasource/FcmDataSourceImpl.kt
+++ b/app/src/main/java/com/ariari/mowoori/data/remote/datasource/FcmDataSourceImpl.kt
@@ -1,0 +1,4 @@
+package com.ariari.mowoori.data.remote.datasource
+
+class FcmDataSourceImpl {
+}

--- a/app/src/main/java/com/ariari/mowoori/data/remote/datasource/FcmDataSourceImpl.kt
+++ b/app/src/main/java/com/ariari/mowoori/data/remote/datasource/FcmDataSourceImpl.kt
@@ -1,4 +1,14 @@
 package com.ariari.mowoori.data.remote.datasource
 
-class FcmDataSourceImpl {
+import com.ariari.mowoori.data.remote.request.FcmRequest
+import com.ariari.mowoori.data.remote.response.FcmResponse
+import com.ariari.mowoori.data.remote.service.FcmService
+import javax.inject.Inject
+
+class FcmDataSourceImpl @Inject constructor(
+    private val fcmService: FcmService
+) : FcmDataSource {
+    override suspend fun postFcmMessage(body: FcmRequest): FcmResponse =
+        fcmService.postMessage(body)
+
 }

--- a/app/src/main/java/com/ariari/mowoori/data/remote/request/FcmRequest.kt
+++ b/app/src/main/java/com/ariari/mowoori/data/remote/request/FcmRequest.kt
@@ -1,12 +1,12 @@
 package com.ariari.mowoori.data.remote.request
 
 data class FcmRequest(
-    val `data`: Data,
+    val to: String,
     val priority: String,
-    val to: String
+    val `data`: FcmData
 )
 
-data class Data(
+data class FcmData(
     val title: String,
-    val message: String
+    val body: String
 )

--- a/app/src/main/java/com/ariari/mowoori/data/remote/request/FcmRequest.kt
+++ b/app/src/main/java/com/ariari/mowoori/data/remote/request/FcmRequest.kt
@@ -1,0 +1,12 @@
+package com.ariari.mowoori.data.remote.request
+
+data class FcmRequest(
+    val `data`: Data,
+    val priority: String,
+    val to: String
+)
+
+data class Data(
+    val title: String,
+    val message: String
+)

--- a/app/src/main/java/com/ariari/mowoori/data/remote/response/FcmResponse.kt
+++ b/app/src/main/java/com/ariari/mowoori/data/remote/response/FcmResponse.kt
@@ -1,0 +1,14 @@
+package com.ariari.mowoori.data.remote.response
+
+data class FcmResponse(
+    val canonical_ids: Int,
+    val failure: Int,
+    val multicast_id: Long,
+    val results: List<FcmResult>,
+    val success: Int
+)
+
+data class FcmResult(
+    val message_id: String
+)
+

--- a/app/src/main/java/com/ariari/mowoori/data/remote/service/FcmService.kt
+++ b/app/src/main/java/com/ariari/mowoori/data/remote/service/FcmService.kt
@@ -3,9 +3,11 @@ package com.ariari.mowoori.data.remote.service
 import com.ariari.mowoori.data.remote.request.FcmRequest
 import com.ariari.mowoori.data.remote.response.FcmResponse
 import retrofit2.http.Body
+import retrofit2.http.Headers
 import retrofit2.http.POST
 
 interface FcmService {
+    @Headers("Authorization:key=AAAAfSwv9Lc:APA91bF1dqg9zinG1J5PhU9DMW6z0oQa9KLQRfSuSoAyTgu3VnNPUouuMdAClhyjD3VAa3YxESR76Myo2zYF4rTZG9he6560JumsAkuMY7nTFIwLQ89lXnvdaIxPg8pEiPHZGdFFN9WN")
     @POST("/fcm/send")
     suspend fun postMessage(
         @Body body: FcmRequest

--- a/app/src/main/java/com/ariari/mowoori/data/remote/service/FcmService.kt
+++ b/app/src/main/java/com/ariari/mowoori/data/remote/service/FcmService.kt
@@ -1,0 +1,13 @@
+package com.ariari.mowoori.data.remote.service
+
+import com.ariari.mowoori.data.remote.request.FcmRequest
+import com.ariari.mowoori.data.remote.response.FcmResponse
+import retrofit2.http.Body
+import retrofit2.http.POST
+
+interface FcmService {
+    @POST("/fcm/send")
+    suspend fun postMessage(
+        @Body body: FcmRequest
+    ): FcmResponse
+}

--- a/app/src/main/java/com/ariari/mowoori/data/repository/IntroRepository.kt
+++ b/app/src/main/java/com/ariari/mowoori/data/repository/IntroRepository.kt
@@ -4,6 +4,10 @@ import android.net.Uri
 import com.ariari.mowoori.ui.register.entity.UserInfo
 
 interface IntroRepository {
+    fun setUserRegistered(isRegistered:Boolean)
+
+    fun getUserRegistered(): Boolean
+
     suspend fun checkUserRegistered(userUid: String): Boolean
 
     suspend fun getRandomNickName(): String

--- a/app/src/main/java/com/ariari/mowoori/data/repository/IntroRepository.kt
+++ b/app/src/main/java/com/ariari/mowoori/data/repository/IntroRepository.kt
@@ -13,4 +13,6 @@ interface IntroRepository {
     suspend fun userRegister(userInfo: UserInfo): Boolean
 
     suspend fun putUserProfile(uri: Uri): String
+
+    suspend fun updateFcmToken(token:String)
 }

--- a/app/src/main/java/com/ariari/mowoori/data/repository/IntroRepositoryImpl.kt
+++ b/app/src/main/java/com/ariari/mowoori/data/repository/IntroRepositoryImpl.kt
@@ -1,6 +1,7 @@
 package com.ariari.mowoori.data.repository
 
 import android.net.Uri
+import com.ariari.mowoori.data.local.datasource.MoWooriPrefDataSource
 import com.ariari.mowoori.ui.register.entity.UserInfo
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.database.DatabaseReference
@@ -12,8 +13,15 @@ import javax.inject.Inject
 class IntroRepositoryImpl @Inject constructor(
     private val firebaseReference: DatabaseReference,
     private val storageReference: StorageReference,
-    private val firebaseAuth: FirebaseAuth
+    private val firebaseAuth: FirebaseAuth,
+    private val preference: MoWooriPrefDataSource
 ) : IntroRepository {
+    override fun setUserRegistered(isRegistered: Boolean) {
+        preference.setUserRegistered(isRegistered)
+    }
+
+    override fun getUserRegistered(): Boolean = preference.getUserRegistered()
+
     override suspend fun checkUserRegistered(userUid: String): Boolean {
         val snapshot = firebaseReference.child("users").child(userUid).get().await()
         return snapshot.value != null

--- a/app/src/main/java/com/ariari/mowoori/data/repository/IntroRepositoryImpl.kt
+++ b/app/src/main/java/com/ariari/mowoori/data/repository/IntroRepositoryImpl.kt
@@ -47,4 +47,8 @@ class IntroRepositoryImpl @Inject constructor(
         val uploadUrl = task.storage.downloadUrl.await()
         return uploadUrl.toString()
     }
+
+    override suspend fun updateFcmToken(token: String) {
+        firebaseReference.child("users/${getUserUid()}/fcmToken").setValue(token)
+    }
 }

--- a/app/src/main/java/com/ariari/mowoori/data/repository/StampsRepository.kt
+++ b/app/src/main/java/com/ariari/mowoori/data/repository/StampsRepository.kt
@@ -1,6 +1,7 @@
 package com.ariari.mowoori.data.repository
 
 import android.net.Uri
+import com.ariari.mowoori.data.remote.response.FcmResponse
 import com.ariari.mowoori.ui.missions.entity.Mission
 import com.ariari.mowoori.ui.missions.entity.MissionInfo
 import com.ariari.mowoori.ui.stamp.entity.StampInfo
@@ -13,4 +14,6 @@ interface StampsRepository {
 
     suspend fun putCertificationImage(uri: Uri, missionId: String): Result<String>
     suspend fun getStampImageUrl(uriString: String): Result<String>
+
+    suspend fun postFcmMessage(): Result<FcmResponse>
 }

--- a/app/src/main/java/com/ariari/mowoori/di/DataSourceModule.kt
+++ b/app/src/main/java/com/ariari/mowoori/di/DataSourceModule.kt
@@ -4,9 +4,8 @@ import android.content.Context
 import android.content.SharedPreferences
 import androidx.security.crypto.EncryptedSharedPreferences
 import androidx.security.crypto.MasterKey
-import com.ariari.mowoori.data.preference.MoWooriPreference
-import com.ariari.mowoori.data.preference.MoWooriPreferenceImpl
-import dagger.Binds
+import com.ariari.mowoori.data.local.datasource.MoWooriPrefDataSource
+import com.ariari.mowoori.data.local.datasource.MoWooriPrefDataSourceImpl
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -29,6 +28,6 @@ object DataSourceModule {
         )
 
     @Provides
-    fun provideMowooriPreference(preferences: SharedPreferences): MoWooriPreference =
-        MoWooriPreferenceImpl(preferences)
+    fun provideMowooriPreference(preferences: SharedPreferences): MoWooriPrefDataSource =
+        MoWooriPrefDataSourceImpl(preferences)
 }

--- a/app/src/main/java/com/ariari/mowoori/di/DataSourceModule.kt
+++ b/app/src/main/java/com/ariari/mowoori/di/DataSourceModule.kt
@@ -2,6 +2,8 @@ package com.ariari.mowoori.di
 
 import android.content.Context
 import android.content.SharedPreferences
+import androidx.security.crypto.EncryptedSharedPreferences
+import androidx.security.crypto.MasterKey
 import com.ariari.mowoori.data.preference.MoWooriPreference
 import com.ariari.mowoori.data.preference.MoWooriPreferenceImpl
 import dagger.Binds
@@ -18,7 +20,13 @@ object DataSourceModule {
     @Provides
     @Singleton
     fun provideSharedPreference(@ApplicationContext context: Context): SharedPreferences =
-        context.getSharedPreferences(context.applicationInfo.packageName, Context.MODE_PRIVATE)
+        EncryptedSharedPreferences.create(
+            context,
+            context.packageName,
+            MasterKey.Builder(context).setKeyScheme(MasterKey.KeyScheme.AES256_GCM).build(),
+            EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
+            EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
+        )
 
     @Provides
     fun provideMowooriPreference(preferences: SharedPreferences): MoWooriPreference =

--- a/app/src/main/java/com/ariari/mowoori/di/DataSourceModule.kt
+++ b/app/src/main/java/com/ariari/mowoori/di/DataSourceModule.kt
@@ -6,6 +6,9 @@ import androidx.security.crypto.EncryptedSharedPreferences
 import androidx.security.crypto.MasterKey
 import com.ariari.mowoori.data.local.datasource.MoWooriPrefDataSource
 import com.ariari.mowoori.data.local.datasource.MoWooriPrefDataSourceImpl
+import com.ariari.mowoori.data.remote.datasource.FcmDataSource
+import com.ariari.mowoori.data.remote.datasource.FcmDataSourceImpl
+import com.ariari.mowoori.data.remote.service.FcmService
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -28,6 +31,10 @@ object DataSourceModule {
         )
 
     @Provides
-    fun provideMowooriPreference(preferences: SharedPreferences): MoWooriPrefDataSource =
+    fun provideMowooriPrefDataSource(preferences: SharedPreferences): MoWooriPrefDataSource =
         MoWooriPrefDataSourceImpl(preferences)
+
+    @Provides
+    fun provideFcmDataSource(fcmService: FcmService): FcmDataSource =
+        FcmDataSourceImpl(fcmService)
 }

--- a/app/src/main/java/com/ariari/mowoori/di/RepositoryModule.kt
+++ b/app/src/main/java/com/ariari/mowoori/di/RepositoryModule.kt
@@ -2,6 +2,7 @@ package com.ariari.mowoori.di
 
 import android.content.SharedPreferences
 import com.ariari.mowoori.data.local.datasource.MoWooriPrefDataSource
+import com.ariari.mowoori.data.remote.datasource.FcmDataSource
 import com.ariari.mowoori.data.repository.GroupRepository
 import com.ariari.mowoori.data.repository.GroupRepositoryImpl
 import com.ariari.mowoori.data.repository.HomeRepository
@@ -63,9 +64,10 @@ object RepositoryModule {
     fun providesStampsRepository(
         databaseReference: DatabaseReference,
         storageReference: StorageReference,
-        firebaseAuth: FirebaseAuth
+        firebaseAuth: FirebaseAuth,
+        fcmDataSource: FcmDataSource
     ): StampsRepository =
-        StampsRepositoryImpl(databaseReference, storageReference, firebaseAuth)
+        StampsRepositoryImpl(databaseReference, storageReference, firebaseAuth, fcmDataSource)
 
     @Provides
     @Singleton

--- a/app/src/main/java/com/ariari/mowoori/di/RepositoryModule.kt
+++ b/app/src/main/java/com/ariari/mowoori/di/RepositoryModule.kt
@@ -1,5 +1,7 @@
 package com.ariari.mowoori.di
 
+import android.content.SharedPreferences
+import com.ariari.mowoori.data.local.datasource.MoWooriPrefDataSource
 import com.ariari.mowoori.data.repository.GroupRepository
 import com.ariari.mowoori.data.repository.GroupRepositoryImpl
 import com.ariari.mowoori.data.repository.HomeRepository
@@ -29,9 +31,10 @@ object RepositoryModule {
     fun providesIntroRepository(
         databaseReference: DatabaseReference,
         storageReference: StorageReference,
-        firebaseAuth: FirebaseAuth
+        firebaseAuth: FirebaseAuth,
+        prefs: MoWooriPrefDataSource
     ): IntroRepository =
-        IntroRepositoryImpl(databaseReference, storageReference, firebaseAuth)
+        IntroRepositoryImpl(databaseReference, storageReference, firebaseAuth, prefs)
 
     @Provides
     @Singleton

--- a/app/src/main/java/com/ariari/mowoori/di/RetrofitModule.kt
+++ b/app/src/main/java/com/ariari/mowoori/di/RetrofitModule.kt
@@ -1,7 +1,5 @@
 package com.ariari.mowoori.di
 
-import com.google.firebase.messaging.FirebaseMessaging
-import com.google.firebase.messaging.RemoteMessage
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn

--- a/app/src/main/java/com/ariari/mowoori/di/RetrofitModule.kt
+++ b/app/src/main/java/com/ariari/mowoori/di/RetrofitModule.kt
@@ -12,7 +12,7 @@ import javax.inject.Singleton
 @Module
 @InstallIn(SingletonComponent::class)
 object RetrofitModule {
-    private const val FCM_URL = "https://fcm.googleapis.com/fcm/send"
+    private const val FCM_URL = "https://fcm.googleapis.com"
 
     @Provides
     @Singleton

--- a/app/src/main/java/com/ariari/mowoori/di/RetrofitModule.kt
+++ b/app/src/main/java/com/ariari/mowoori/di/RetrofitModule.kt
@@ -1,0 +1,28 @@
+package com.ariari.mowoori.di
+
+import com.google.firebase.messaging.FirebaseMessaging
+import com.google.firebase.messaging.RemoteMessage
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import retrofit2.Retrofit
+import retrofit2.converter.gson.GsonConverterFactory
+import javax.inject.Named
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object RetrofitModule {
+    private const val FCM_URL = "https://fcm.googleapis.com/fcm/send"
+
+    @Provides
+    @Singleton
+    @Named("FcmRetrofit")
+    fun providesFcmRetrofit(): Retrofit =
+        Retrofit.Builder()
+            .baseUrl(FCM_URL)
+            .addConverterFactory(GsonConverterFactory.create())
+            .build()
+
+}

--- a/app/src/main/java/com/ariari/mowoori/di/RetrofitServiceModule.kt
+++ b/app/src/main/java/com/ariari/mowoori/di/RetrofitServiceModule.kt
@@ -6,6 +6,7 @@ import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import retrofit2.Retrofit
+import javax.inject.Named
 import javax.inject.Singleton
 
 @Module
@@ -13,6 +14,6 @@ import javax.inject.Singleton
 object RetrofitServiceModule {
     @Provides
     @Singleton
-    fun providesFcmService(retrofit: Retrofit): FcmService =
+    fun providesFcmService(@Named("FcmRetrofit") retrofit: Retrofit): FcmService =
         retrofit.create(FcmService::class.java)
 }

--- a/app/src/main/java/com/ariari/mowoori/di/RetrofitServiceModule.kt
+++ b/app/src/main/java/com/ariari/mowoori/di/RetrofitServiceModule.kt
@@ -1,0 +1,18 @@
+package com.ariari.mowoori.di
+
+import com.ariari.mowoori.data.remote.service.FcmService
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import retrofit2.Retrofit
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object RetrofitServiceModule {
+    @Provides
+    @Singleton
+    fun providesFcmService(retrofit: Retrofit): FcmService =
+        retrofit.create(FcmService::class.java)
+}

--- a/app/src/main/java/com/ariari/mowoori/ui/intro/IntroActivity.kt
+++ b/app/src/main/java/com/ariari/mowoori/ui/intro/IntroActivity.kt
@@ -12,7 +12,6 @@ import androidx.core.content.ContextCompat
 import androidx.core.view.isVisible
 import com.ariari.mowoori.BuildConfig
 import com.ariari.mowoori.R
-import com.ariari.mowoori.data.preference.MoWooriPreference
 import com.ariari.mowoori.databinding.ActivityIntroBinding
 import com.ariari.mowoori.ui.main.MainActivity
 import com.ariari.mowoori.ui.register.RegisterActivity
@@ -23,7 +22,6 @@ import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.auth.GoogleAuthProvider
 import dagger.hilt.android.AndroidEntryPoint
 import timber.log.Timber
-import javax.inject.Inject
 
 @AndroidEntryPoint
 class IntroActivity : AppCompatActivity() {
@@ -44,9 +42,6 @@ class IntroActivity : AppCompatActivity() {
         android.Manifest.permission.WRITE_EXTERNAL_STORAGE,
         android.Manifest.permission.READ_EXTERNAL_STORAGE
     )
-
-    @Inject
-    lateinit var preference: MoWooriPreference
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -80,7 +75,7 @@ class IntroActivity : AppCompatActivity() {
         introViewModel.isUserRegistered.observe(this, EventObserver {
             if (it) {
                 introViewModel.updateFcmToken()
-                preference.setUserRegistered(true)
+                introViewModel.setUserRegistered(true)
                 moveToMain()
             } else {
                 moveToRegister()
@@ -134,7 +129,7 @@ class IntroActivity : AppCompatActivity() {
     }
 
     private fun autoLogin() {
-        if (auth.currentUser != null && preference.getUserRegistered()) {
+        if (auth.currentUser != null && introViewModel.getUserRegistered()) {
             signIn()
         }
         else{

--- a/app/src/main/java/com/ariari/mowoori/ui/intro/IntroViewModel.kt
+++ b/app/src/main/java/com/ariari/mowoori/ui/intro/IntroViewModel.kt
@@ -22,6 +22,11 @@ class IntroViewModel @Inject constructor(
 
     private var fcmToken = ""
 
+    fun setUserRegistered(isRegistered:Boolean){
+        introRepository.setUserRegistered(isRegistered)
+    }
+
+    fun getUserRegistered() = introRepository.getUserRegistered()
 
     fun checkUserRegistered(userUid: String) {
         viewModelScope.launch(Dispatchers.IO) {

--- a/app/src/main/java/com/ariari/mowoori/ui/intro/IntroViewModel.kt
+++ b/app/src/main/java/com/ariari/mowoori/ui/intro/IntroViewModel.kt
@@ -6,6 +6,8 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.ariari.mowoori.data.repository.IntroRepository
 import com.ariari.mowoori.util.Event
+import com.google.android.gms.tasks.OnCompleteListener
+import com.google.firebase.messaging.FirebaseMessaging
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -18,10 +20,27 @@ class IntroViewModel @Inject constructor(
     private val _isUserRegistered = MutableLiveData<Event<Boolean>>()
     val isUserRegistered: LiveData<Event<Boolean>> = _isUserRegistered
 
+    private var fcmToken = ""
+
+
     fun checkUserRegistered(userUid: String) {
         viewModelScope.launch(Dispatchers.IO) {
             val isRegistered = introRepository.checkUserRegistered(userUid)
             _isUserRegistered.postValue(Event(isRegistered))
         }
     }
+
+    fun initFcmToken() {
+        FirebaseMessaging.getInstance().token.addOnCompleteListener(OnCompleteListener { task ->
+            if (!task.isSuccessful) {
+                return@OnCompleteListener
+            }
+            fcmToken = task.result.toString()
+        })
+    }
+
+    fun updateFcmToken() {
+        viewModelScope.launch(Dispatchers.IO) { introRepository.updateFcmToken(fcmToken) }
+    }
+
 }

--- a/app/src/main/java/com/ariari/mowoori/ui/register/RegisterActivity.kt
+++ b/app/src/main/java/com/ariari/mowoori/ui/register/RegisterActivity.kt
@@ -10,7 +10,7 @@ import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.DialogFragment
 import com.ariari.mowoori.R
-import com.ariari.mowoori.data.preference.MoWooriPreference
+import com.ariari.mowoori.data.local.datasource.MoWooriPrefDataSource
 import com.ariari.mowoori.databinding.ActivityRegisterBinding
 import com.ariari.mowoori.ui.main.MainActivity
 import com.ariari.mowoori.util.EventObserver
@@ -24,28 +24,26 @@ import javax.inject.Inject
 @AndroidEntryPoint
 class RegisterActivity : AppCompatActivity() {
 
-    private val viewModel: RegisterViewModel by viewModels()
+    private val registerViewModel: RegisterViewModel by viewModels()
     private val binding by lazy {
         ActivityRegisterBinding.inflate(layoutInflater)
     }
     private val getContent = registerForActivityResult(ActivityResultContracts.GetContent()) {
         it?.let {
-            viewModel.setProfileImage(it)
+            registerViewModel.setProfileImage(it)
         }
     }
-    @Inject
-    lateinit var preference: MoWooriPreference
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(binding.root)
-        binding.viewModel = viewModel
+        binding.viewModel = registerViewModel
         binding.lifecycleOwner = this
         setObservers()
         setRootClick()
         setCompleteClick()
-        viewModel.createNickName()
-        viewModel.initFcmToken()
+        registerViewModel.createNickName()
+        registerViewModel.initFcmToken()
     }
 
     private fun setObservers() {
@@ -74,7 +72,7 @@ class RegisterActivity : AppCompatActivity() {
         binding.btnRegisterComplete.setOnClickListener {
             ConfirmDialogFragment(object : BaseDialogFragment.NoticeDialogListener {
                 override fun onDialogPositiveClick(dialog: DialogFragment) {
-                    viewModel.registerUserInfo()
+                    registerViewModel.registerUserInfo()
                 }
 
                 override fun onDialogNegativeClick(dialog: DialogFragment) {
@@ -85,17 +83,17 @@ class RegisterActivity : AppCompatActivity() {
     }
 
     private fun setInvalidNickNameObserver() {
-        viewModel.invalidNicknameEvent.observe(this, EventObserver {
+        registerViewModel.invalidNicknameEvent.observe(this, EventObserver {
             ProgressDialogManager.instance.clear()
             toastMessage(getString(R.string.register_nickname_error_msg))
         })
     }
 
     private fun setRegisterSuccessObserver() {
-        viewModel.registerSuccessEvent.observe(this, EventObserver {
+        registerViewModel.registerSuccessEvent.observe(this, EventObserver {
             ProgressDialogManager.instance.clear()
             if (it) {
-                preference.setUserRegistered(true)
+                registerViewModel.setUserRegistered(true)
                 moveToMain()
             } else {
                 toastMessage(getString(R.string.register_fail_msg))
@@ -104,13 +102,13 @@ class RegisterActivity : AppCompatActivity() {
     }
 
     private fun setProfileClickObserver() {
-        viewModel.profileImageClickEvent.observe(this, EventObserver {
+        registerViewModel.profileImageClickEvent.observe(this, EventObserver {
             getContent.launch("image/*")
         })
     }
 
     private fun setLoadingEventObserver() {
-        viewModel.loadingEvent.observe(this, EventObserver {
+        registerViewModel.loadingEvent.observe(this, EventObserver {
             if (it) {
                 ProgressDialogManager.instance.show(this)
             } else {

--- a/app/src/main/java/com/ariari/mowoori/ui/register/RegisterActivity.kt
+++ b/app/src/main/java/com/ariari/mowoori/ui/register/RegisterActivity.kt
@@ -45,6 +45,7 @@ class RegisterActivity : AppCompatActivity() {
         setRootClick()
         setCompleteClick()
         viewModel.createNickName()
+        viewModel.initFcmToken()
     }
 
     private fun setObservers() {

--- a/app/src/main/java/com/ariari/mowoori/ui/register/RegisterViewModel.kt
+++ b/app/src/main/java/com/ariari/mowoori/ui/register/RegisterViewModel.kt
@@ -52,6 +52,10 @@ class RegisterViewModel @Inject constructor(
         _profileImageUri.postValue(uri)
     }
 
+    fun setUserRegistered(isRegistered:Boolean){
+        introRepository.setUserRegistered(isRegistered)
+    }
+
     fun registerUserInfo() {
         _loadingEvent.value = Event(true)
         val nickname = profileText.value ?: ""

--- a/app/src/main/java/com/ariari/mowoori/ui/register/RegisterViewModel.kt
+++ b/app/src/main/java/com/ariari/mowoori/ui/register/RegisterViewModel.kt
@@ -8,6 +8,8 @@ import androidx.lifecycle.viewModelScope
 import com.ariari.mowoori.data.repository.IntroRepository
 import com.ariari.mowoori.ui.register.entity.UserInfo
 import com.ariari.mowoori.util.Event
+import com.google.android.gms.tasks.OnCompleteListener
+import com.google.firebase.messaging.FirebaseMessaging
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -29,6 +31,8 @@ class RegisterViewModel @Inject constructor(
 
     private val _profileImageUri = MutableLiveData<Uri>()
     val profileImageUri: LiveData<Uri> = _profileImageUri
+
+    private var fcmToken = ""
 
     private val _loadingEvent = MutableLiveData<Event<Boolean>>()
     val loadingEvent: LiveData<Event<Boolean>> = _loadingEvent
@@ -63,11 +67,21 @@ class RegisterViewModel @Inject constructor(
             val success = introRepository.userRegister(
                 UserInfo(
                     nickname = nickname,
-                    profileImage = uploadUrl
+                    profileImage = uploadUrl,
+                    fcmToken = fcmToken
                 )
             )
             _registerSuccessEvent.postValue(Event(success))
         }
+    }
+
+    fun initFcmToken() {
+        FirebaseMessaging.getInstance().token.addOnCompleteListener(OnCompleteListener { task ->
+            if (!task.isSuccessful) {
+                return@OnCompleteListener
+            }
+            fcmToken = task.result.toString()
+        })
     }
 
     private fun checkNicknameValid(nickname: String): Boolean {

--- a/app/src/main/java/com/ariari/mowoori/ui/register/entity/User.kt
+++ b/app/src/main/java/com/ariari/mowoori/ui/register/entity/User.kt
@@ -13,6 +13,7 @@ data class User(
 data class UserInfo(
     val nickname: String = "",
     val profileImage: String = "",
+    val fcmToken: String = "",
     val groupList: List<String> = emptyList(),
     val currentGroupId: String = ""
 ) : Parcelable

--- a/app/src/main/java/com/ariari/mowoori/ui/stamp/StampsViewModel.kt
+++ b/app/src/main/java/com/ariari/mowoori/ui/stamp/StampsViewModel.kt
@@ -102,4 +102,15 @@ class StampsViewModel @Inject constructor(
                 }
         }
     }
+
+    fun postFcm() {
+        LogUtil.log("fcm","fcm")
+        viewModelScope.launch {
+            stampsRepository.postFcmMessage().onSuccess {
+                LogUtil.log("fcm", it.success.toString())
+            }.onFailure {
+                LogUtil.log("fcm", it.message.toString())
+            }
+        }
+    }
 }

--- a/app/src/main/java/com/ariari/mowoori/util/MowooriMessagingService.kt
+++ b/app/src/main/java/com/ariari/mowoori/util/MowooriMessagingService.kt
@@ -1,0 +1,60 @@
+package com.ariari.mowoori.util
+
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import android.os.Build
+import androidx.core.app.NotificationCompat
+import com.ariari.mowoori.R
+import com.ariari.mowoori.ui.main.MainActivity
+import com.google.firebase.messaging.FirebaseMessagingService
+import com.google.firebase.messaging.RemoteMessage
+
+class MowooriMessagingService : FirebaseMessagingService() {
+    override fun onNewToken(token: String) {
+        super.onNewToken(token)
+    }
+
+    override fun onMessageReceived(remoteMessage: RemoteMessage) {
+        super.onMessageReceived(remoteMessage)
+        if (remoteMessage.data.isNotEmpty()) {
+            notifyFcm(remoteMessage)
+        }
+
+    }
+
+    private fun notifyFcm(remoteMessage: RemoteMessage) {
+        val alarmId = remoteMessage.sentTime.toInt()
+        val intent = Intent(this, MainActivity::class.java)
+        intent.putExtra("openFromFcm", true)
+        intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP)
+        val pendingIntent =
+            PendingIntent.getActivity(this, FLOAT_NOTIFICATION, intent, PendingIntent.FLAG_ONE_SHOT)
+        val builder =
+            NotificationCompat.Builder(this, getString(R.string.app_name))
+                .setContentTitle(remoteMessage.data["title"])
+                .setContentText(remoteMessage.data["body"])
+                .setSmallIcon(R.mipmap.ic_app_logo)
+                .setContentIntent(pendingIntent)
+                .setPriority(NotificationCompat.PRIORITY_MAX)
+                .setAutoCancel(true)
+        val notificationManager =
+            getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val channelId = getString(R.string.app_name)
+            val channelName = getString(R.string.app_name)
+            val channelImportance = NotificationManager.IMPORTANCE_HIGH
+            val channel = NotificationChannel(channelId, channelName, channelImportance)
+            notificationManager.createNotificationChannel(channel)
+        }
+
+        notificationManager.notify(alarmId, builder.build())
+    }
+
+    companion object {
+        const val FLOAT_NOTIFICATION = 0
+    }
+}

--- a/app/src/main/java/com/ariari/mowoori/util/MowooriMessagingService.kt
+++ b/app/src/main/java/com/ariari/mowoori/util/MowooriMessagingService.kt
@@ -31,7 +31,7 @@ class MowooriMessagingService : FirebaseMessagingService() {
         intent.putExtra("openFromFcm", true)
         intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP)
         val pendingIntent =
-            PendingIntent.getActivity(this, FLOAT_NOTIFICATION, intent, PendingIntent.FLAG_ONE_SHOT)
+            PendingIntent.getActivity(this, FLOAT_NOTIFICATION, intent, PendingIntent.FLAG_MUTABLE)
         val builder =
             NotificationCompat.Builder(this, getString(R.string.app_name))
                 .setContentTitle(remoteMessage.data["title"])

--- a/app/src/main/java/com/ariari/mowoori/util/MowooriMessagingService.kt
+++ b/app/src/main/java/com/ariari/mowoori/util/MowooriMessagingService.kt
@@ -35,7 +35,7 @@ class MowooriMessagingService : FirebaseMessagingService() {
         val builder =
             NotificationCompat.Builder(this, getString(R.string.app_name))
                 .setContentTitle(remoteMessage.data[TITLE])
-                .setContentText(remoteMessage.data[MSG])
+                .setContentText(remoteMessage.data[BODY])
                 .setSmallIcon(R.mipmap.ic_app_logo)
                 .setContentIntent(pendingIntent)
                 .setPriority(NotificationCompat.PRIORITY_MAX)
@@ -57,6 +57,6 @@ class MowooriMessagingService : FirebaseMessagingService() {
     companion object {
         const val FLOAT_NOTIFICATION = 0
         const val TITLE = "title"
-        const val MSG = "message"
+        const val BODY = "body"
     }
 }

--- a/app/src/main/java/com/ariari/mowoori/util/MowooriMessagingService.kt
+++ b/app/src/main/java/com/ariari/mowoori/util/MowooriMessagingService.kt
@@ -34,8 +34,8 @@ class MowooriMessagingService : FirebaseMessagingService() {
             PendingIntent.getActivity(this, FLOAT_NOTIFICATION, intent, PendingIntent.FLAG_MUTABLE)
         val builder =
             NotificationCompat.Builder(this, getString(R.string.app_name))
-                .setContentTitle(remoteMessage.data["title"])
-                .setContentText(remoteMessage.data["body"])
+                .setContentTitle(remoteMessage.data[TITLE])
+                .setContentText(remoteMessage.data[MSG])
                 .setSmallIcon(R.mipmap.ic_app_logo)
                 .setContentIntent(pendingIntent)
                 .setPriority(NotificationCompat.PRIORITY_MAX)
@@ -56,5 +56,7 @@ class MowooriMessagingService : FirebaseMessagingService() {
 
     companion object {
         const val FLOAT_NOTIFICATION = 0
+        const val TITLE = "title"
+        const val MSG = "message"
     }
 }

--- a/app/src/main/res/layout/fragment_stamps.xml
+++ b/app/src/main/res/layout/fragment_stamps.xml
@@ -28,6 +28,14 @@
             app:titleViewMode="@{TitleViewMode.TITLE_VIEW_BACK_BUTTON}"
             app:titleViewText="@{viewModel.mission.missionInfo.missionName}" />
 
+        <Button
+            android:onClick="@{()->viewModel.postFcm()}"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            android:text="fcm"/>
+
         <androidx.recyclerview.widget.RecyclerView
             android:id="@+id/rv_stamps"
             android:layout_width="match_parent"


### PR DESCRIPTION
# ❗️ 이슈 트래킹
- #27 

# 💡 작업목록
- gradle에 FCM 설정 추가
- Manifestdp FirebaseMessagingService 확장하는 서비스 추가
- MowooriMessagingService에 FCM 받았을 시 동작 구현
- 유저 회원가입 시 fcmToken userInfo로 함께 등록
- 유저 로그인 시 마다 fcmToken 갱신
- FCM post 요청 위해 Retrofit 설정
- FCM 통신 위한 Service, DataSource 생성 및 DI 모듈에 추가
- FCM 클라이언트에서 post 하기

# ❓ 고민과 해결
- 서버가 없어서 FCM을 어디서 보내야할지 고민이었고, 클라이언트에서 서버키를 가지고 post를 할까 생각도 했지만 클라이언트에 서버키를 갖고있는 것은 위험하다고 생각했고, realtimeDatabase와 함께 쓰는 functions으로 구현해볼 생각이었다. 하지만 functions가 유료 서비스였기 때문에 어쩔 수 없이 클라이언트에서 서버키를 갖고 있도록 구현했다. 대신 EncryptedSharedPreferences에 넣어볼 생각이다.


