### PR TITLE
[25-1] 그룹 생성/참여 화면, 구성원 화면 네트워크 연결 분기 처리

### DIFF
--- a/app/src/main/java/com/ariari/mowoori/data/repository/IntroRepository.kt
+++ b/app/src/main/java/com/ariari/mowoori/data/repository/IntroRepository.kt
@@ -10,7 +10,7 @@ interface IntroRepository {
 
     suspend fun checkUserRegistered(userUid: String): Boolean
 
-    suspend fun getRandomNickName(): String
+    suspend fun getRandomNickName(): Result<String>
 
     fun getUserUid(): String?
 

--- a/app/src/main/java/com/ariari/mowoori/data/repository/IntroRepositoryImpl.kt
+++ b/app/src/main/java/com/ariari/mowoori/data/repository/IntroRepositoryImpl.kt
@@ -8,6 +8,7 @@ import com.google.firebase.database.DatabaseReference
 import com.google.firebase.database.GenericTypeIndicator
 import com.google.firebase.storage.StorageReference
 import kotlinx.coroutines.tasks.await
+import java.lang.NullPointerException
 import javax.inject.Inject
 
 class IntroRepositoryImpl @Inject constructor(
@@ -27,14 +28,14 @@ class IntroRepositoryImpl @Inject constructor(
         return snapshot.value != null
     }
 
-    override suspend fun getRandomNickName(): String {
+    override suspend fun getRandomNickName(): Result<String> = runCatching {
         val namesRef = firebaseReference.child("names").get().await()
         val map =
             namesRef.getValue(object : GenericTypeIndicator<HashMap<String, List<String>>>() {})
-                ?: return ""
-        val prefixList = map["prefix"] ?: return ""
-        val nameList = map["name"] ?: return ""
-        return "${prefixList.random()} ${nameList.random()}"
+                ?: throw NullPointerException("invalid path")
+        val prefixList = map["prefix"] ?: throw NullPointerException("invalid key")
+        val nameList = map["name"] ?: throw NullPointerException("invalid key")
+        "${prefixList.random()} ${nameList.random()}"
     }
 
     override fun getUserUid(): String? {

--- a/app/src/main/java/com/ariari/mowoori/data/repository/MembersRepository.kt
+++ b/app/src/main/java/com/ariari/mowoori/data/repository/MembersRepository.kt
@@ -8,5 +8,5 @@ interface MembersRepository {
 
     fun getUserUid(): String?
 
-    suspend fun getUserInfo(userId:String): User?
+    suspend fun getUserInfo(userId:String): Result<User>
 }

--- a/app/src/main/java/com/ariari/mowoori/data/repository/MembersRepositoryImpl.kt
+++ b/app/src/main/java/com/ariari/mowoori/data/repository/MembersRepositoryImpl.kt
@@ -11,7 +11,7 @@ import javax.inject.Inject
 
 class MembersRepositoryImpl @Inject constructor(
     private val databaseReference: DatabaseReference,
-    private val firebaseAuth: FirebaseAuth
+    private val firebaseAuth: FirebaseAuth,
 ) : MembersRepository {
     override suspend fun getCurrentGroupInfo(): Result<Group> = kotlin.runCatching {
         val uid = getUserUid() ?: throw NullPointerException("userId is Null")
@@ -28,12 +28,12 @@ class MembersRepositoryImpl @Inject constructor(
 
     override fun getUserUid(): String? = firebaseAuth.currentUser?.uid
 
-    override suspend fun getUserInfo(userId: String): User? =
+    override suspend fun getUserInfo(userId: String): Result<User> =
         kotlin.runCatching {
             val userSnapshot = databaseReference.child("users/$userId").get().await()
             User(
                 userId,
                 userSnapshot.getValue(UserInfo::class.java) ?: UserInfo()
             )
-        }.getOrNull()
+        }
 }

--- a/app/src/main/java/com/ariari/mowoori/ui/group/GroupFragment.kt
+++ b/app/src/main/java/com/ariari/mowoori/ui/group/GroupFragment.kt
@@ -8,6 +8,7 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.core.view.isVisible
 import androidx.core.widget.doOnTextChanged
+import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
@@ -15,7 +16,9 @@ import androidx.navigation.fragment.navArgs
 import com.ariari.mowoori.R
 import com.ariari.mowoori.databinding.FragmentGroupBinding
 import com.ariari.mowoori.ui.group.entity.GroupMode
+import com.ariari.mowoori.util.isNetWorkAvailable
 import com.ariari.mowoori.util.toastMessage
+import com.ariari.mowoori.widget.NetworkDialogFragment
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
@@ -49,6 +52,7 @@ class GroupFragment : Fragment() {
         setAddGroupCompleteObserver()
         setOnCompleteClickListener()
         setGroupNameChangeListener()
+        setNetworkDialogObserver()
         when (args.groupMode) {
             GroupMode.INVITE -> {
                 setTitle(R.string.group_invite_title)
@@ -92,14 +96,44 @@ class GroupFragment : Fragment() {
 
     private fun setOnCompleteClickListener() {
         binding.btnGroupComplete.setOnClickListener {
-            when (args.groupMode) {
-                GroupMode.INVITE -> {
-                    viewModel.joinGroup()
-                }
-                GroupMode.NEW -> {
-                    viewModel.addNewGroup()
-                }
+            if (requireContext().isNetWorkAvailable()) {
+                joinOrAddGroup(args.groupMode)
+            } else {
+                showNetworkDialog()
             }
         }
+    }
+
+    private fun joinOrAddGroup(groupMode: GroupMode) {
+        when (groupMode) {
+            GroupMode.INVITE -> {
+                viewModel.joinGroup()
+            }
+            GroupMode.NEW -> {
+                viewModel.addNewGroup()
+            }
+        }
+    }
+
+    private fun setNetworkDialogObserver() {
+        viewModel.networkDialogEvent.observe(viewLifecycleOwner, {
+            if (it) {
+                showNetworkDialog()
+            }
+        })
+    }
+
+    private fun showNetworkDialog() {
+        NetworkDialogFragment(object : NetworkDialogFragment.NetworkDialogListener {
+            override fun onCancelClick(dialog: DialogFragment) {
+                dialog.dismiss()
+                findNavController().navigate(R.id.action_groupNameFragment_to_homeFragment)
+            }
+
+            override fun onRetryClick(dialog: DialogFragment) {
+                dialog.dismiss()
+                joinOrAddGroup(args.groupMode)
+            }
+        }).show(requireActivity().supportFragmentManager, "NetworkDialogFragment")
     }
 }

--- a/app/src/main/java/com/ariari/mowoori/ui/group/GroupFragment.kt
+++ b/app/src/main/java/com/ariari/mowoori/ui/group/GroupFragment.kt
@@ -96,22 +96,22 @@ class GroupFragment : Fragment() {
 
     private fun setOnCompleteClickListener() {
         binding.btnGroupComplete.setOnClickListener {
-            if (requireContext().isNetWorkAvailable()) {
-                joinOrAddGroup(args.groupMode)
-            } else {
-                showNetworkDialog()
-            }
+            joinOrAddGroup()
         }
     }
 
-    private fun joinOrAddGroup(groupMode: GroupMode) {
-        when (groupMode) {
-            GroupMode.INVITE -> {
-                viewModel.joinGroup()
+    private fun joinOrAddGroup() {
+        if (requireContext().isNetWorkAvailable()) {
+            when (args.groupMode) {
+                GroupMode.INVITE -> {
+                    viewModel.joinGroup()
+                }
+                GroupMode.NEW -> {
+                    viewModel.addNewGroup()
+                }
             }
-            GroupMode.NEW -> {
-                viewModel.addNewGroup()
-            }
+        } else {
+            showNetworkDialog()
         }
     }
 
@@ -132,7 +132,7 @@ class GroupFragment : Fragment() {
 
             override fun onRetryClick(dialog: DialogFragment) {
                 dialog.dismiss()
-                joinOrAddGroup(args.groupMode)
+                joinOrAddGroup()
             }
         }).show(requireActivity().supportFragmentManager, "NetworkDialogFragment")
     }

--- a/app/src/main/java/com/ariari/mowoori/ui/group/GroupViewModel.kt
+++ b/app/src/main/java/com/ariari/mowoori/ui/group/GroupViewModel.kt
@@ -42,7 +42,7 @@ class GroupViewModel @Inject constructor(
     }
 
     private fun checkRequestCount() {
-        if (requestCount > 1) {
+        if (requestCount == 1) {
             setNetworkDialogEvent()
         }
     }

--- a/app/src/main/java/com/ariari/mowoori/ui/group/GroupViewModel.kt
+++ b/app/src/main/java/com/ariari/mowoori/ui/group/GroupViewModel.kt
@@ -19,7 +19,7 @@ class GroupViewModel @Inject constructor(
     private val introRepository: IntroRepository,
 ) : ViewModel() {
 
-    val groupName = MutableLiveData<String>("")
+    val groupName = MutableLiveData("")
 
     private val _addGroupCompleteEvent = MutableLiveData<Event<String>>()
     val addGroupCompleteEvent: LiveData<Event<String>> = _addGroupCompleteEvent
@@ -27,10 +27,14 @@ class GroupViewModel @Inject constructor(
     private val _inValidEvent = MutableLiveData<Event<Unit>>()
     val inValidEvent: LiveData<Event<Unit>> = _inValidEvent
 
+    private val _networkDialogEvent = MutableLiveData<Boolean>()
+    val networkDialogEvent: LiveData<Boolean> get() = _networkDialogEvent
+
     fun setGroupName() {
         viewModelScope.launch(Dispatchers.IO) {
-            val randomName = introRepository.getRandomNickName()
-            groupName.postValue(randomName + "들")
+            introRepository.getRandomNickName()
+                .onSuccess { randomName -> groupName.postValue(randomName + "들") }
+                .onFailure { setNetworkDialogEvent() }
         }
     }
 
@@ -41,31 +45,46 @@ class GroupViewModel @Inject constructor(
             if (!exist) {
                 _inValidEvent.postValue(Event(Unit))
             } else {
-                groupRepository.getUser().onSuccess {
-                    groupRepository.addUserToGroup(name, it).onSuccess { newGroupId ->
-                        _addGroupCompleteEvent.postValue(Event(newGroupId))
+                groupRepository.getUser()
+                    .onSuccess {
+                        groupRepository.addUserToGroup(name, it)
+                            .onSuccess { newGroupId ->
+                                _addGroupCompleteEvent.postValue(Event(newGroupId))
+                            }
+                            .onFailure {
+                                _addGroupCompleteEvent.postValue(Event(""))
+                                setNetworkDialogEvent()
+                            }
                     }.onFailure {
                         _addGroupCompleteEvent.postValue(Event(""))
+                        setNetworkDialogEvent()
                     }
-                }.onFailure {
-                    _addGroupCompleteEvent.postValue(Event(""))
-                }
             }
         }
     }
 
-
     fun addNewGroup() {
         viewModelScope.launch(Dispatchers.IO) {
-            groupRepository.getUser().onSuccess {
-                val name = groupName.value ?: return@launch
-                val groupInfo = GroupInfo(0, name, listOf(it.userId))
-                groupRepository.putGroupInfo(groupInfo, it).onSuccess { newGroupId ->
-                    _addGroupCompleteEvent.postValue(Event(newGroupId))
-                }.onFailure {
-                    _addGroupCompleteEvent.postValue(Event(""))
+            groupRepository.getUser()
+                .onSuccess {
+                    val name = groupName.value ?: return@launch
+                    val groupInfo = GroupInfo(0, name, listOf(it.userId))
+                    groupRepository.putGroupInfo(groupInfo, it)
+                        .onSuccess { newGroupId ->
+                            _addGroupCompleteEvent.postValue(Event(newGroupId))
+                        }
+                        .onFailure {
+                            _addGroupCompleteEvent.postValue(Event(""))
+                            setNetworkDialogEvent()
+                        }
                 }
-            }
+                .onFailure {
+                    setNetworkDialogEvent()
+                }
         }
+    }
+
+    private fun setNetworkDialogEvent() {
+        _networkDialogEvent.postValue(true)
     }
 }

--- a/app/src/main/java/com/ariari/mowoori/ui/members/MembersFragment.kt
+++ b/app/src/main/java/com/ariari/mowoori/ui/members/MembersFragment.kt
@@ -16,8 +16,10 @@ import com.ariari.mowoori.databinding.FragmentMembersBinding
 import com.ariari.mowoori.ui.members.adapter.MembersAdapter
 import com.ariari.mowoori.ui.register.entity.User
 import com.ariari.mowoori.util.EventObserver
+import com.ariari.mowoori.util.isNetWorkAvailable
 import com.ariari.mowoori.util.toastMessage
 import com.ariari.mowoori.widget.InviteDialogFragment
+import com.ariari.mowoori.widget.NetworkDialogFragment
 import com.ariari.mowoori.widget.ProgressDialogManager
 import dagger.hilt.android.AndroidEntryPoint
 
@@ -30,13 +32,24 @@ class MembersFragment : BaseFragment<FragmentMembersBinding>(R.layout.fragment_m
         super.onViewCreated(view, savedInstanceState)
         binding.lifecycleOwner = viewLifecycleOwner
         binding.viewModel = membersViewModel
-        membersViewModel.setLoadingEvent(true)
-        membersViewModel.fetchGroupInfo()
+        setGroupInfo()
         setLoadingObserver()
         setOpenDialogEventObserver()
         setCurrentGroupObserver()
         setMembersListObserver()
         setMembersRvAdapter()
+        setNetworkDialogObserver()
+    }
+
+    private fun setGroupInfo() {
+//        if (requireContext().isNetWorkAvailable()) {
+//            membersViewModel.setLoadingEvent(true)
+//            membersViewModel.fetchGroupInfo()
+//        } else {
+//            showNetworkDialog()
+//        }
+        membersViewModel.setLoadingEvent(true)
+        membersViewModel.fetchGroupInfo()
     }
 
     private fun setLoadingObserver() {
@@ -113,4 +126,25 @@ class MembersFragment : BaseFragment<FragmentMembersBinding>(R.layout.fragment_m
         )
     }
 
+    private fun setNetworkDialogObserver() {
+        membersViewModel.networkDialogEvent.observe(viewLifecycleOwner, EventObserver {
+            if (it) {
+                showNetworkDialog()
+            }
+        })
+    }
+
+    private fun showNetworkDialog() {
+        NetworkDialogFragment(object : NetworkDialogFragment.NetworkDialogListener {
+            override fun onCancelClick(dialog: DialogFragment) {
+                dialog.dismiss()
+                findNavController().navigate(R.id.action_membersFragment_to_homeFragment)
+            }
+
+            override fun onRetryClick(dialog: DialogFragment) {
+                dialog.dismiss()
+                membersViewModel.fetchGroupInfo()
+            }
+        }).show(requireActivity().supportFragmentManager, "NetworkDialogFragment")
+    }
 }

--- a/app/src/main/java/com/ariari/mowoori/ui/members/MembersFragment.kt
+++ b/app/src/main/java/com/ariari/mowoori/ui/members/MembersFragment.kt
@@ -42,14 +42,12 @@ class MembersFragment : BaseFragment<FragmentMembersBinding>(R.layout.fragment_m
     }
 
     private fun setGroupInfo() {
-//        if (requireContext().isNetWorkAvailable()) {
-//            membersViewModel.setLoadingEvent(true)
-//            membersViewModel.fetchGroupInfo()
-//        } else {
-//            showNetworkDialog()
-//        }
-        membersViewModel.setLoadingEvent(true)
-        membersViewModel.fetchGroupInfo()
+        if (requireContext().isNetWorkAvailable()) {
+            membersViewModel.setLoadingEvent(true)
+            membersViewModel.fetchGroupInfo()
+        } else {
+            showNetworkDialog()
+        }
     }
 
     private fun setLoadingObserver() {
@@ -143,7 +141,7 @@ class MembersFragment : BaseFragment<FragmentMembersBinding>(R.layout.fragment_m
 
             override fun onRetryClick(dialog: DialogFragment) {
                 dialog.dismiss()
-                membersViewModel.fetchGroupInfo()
+                setGroupInfo()
             }
         }).show(requireActivity().supportFragmentManager, "NetworkDialogFragment")
     }

--- a/app/src/main/java/com/ariari/mowoori/ui/members/MembersViewModel.kt
+++ b/app/src/main/java/com/ariari/mowoori/ui/members/MembersViewModel.kt
@@ -13,6 +13,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
+import timber.log.Timber
 import javax.inject.Inject
 
 @HiltViewModel
@@ -31,15 +32,22 @@ class MembersViewModel @Inject constructor(
     private val _membersList = MutableLiveData<List<User>>()
     val membersList: LiveData<List<User>> = _membersList
 
+    private val _networkDialogEvent = MutableLiveData<Event<Boolean>>()
+    val networkDialogEvent: LiveData<Event<Boolean>> get() = _networkDialogEvent
+
     fun setLoadingEvent(isLoading: Boolean) {
-        _loadingEvent.value = Event(isLoading)
+        _loadingEvent.postValue(Event(isLoading))
     }
 
     fun fetchGroupInfo() {
         viewModelScope.launch(Dispatchers.IO) {
-            membersRepository.getCurrentGroupInfo().onSuccess {
-                _currentGroup.postValue(it)
-            }
+            membersRepository.getCurrentGroupInfo()
+                .onSuccess {
+                    _currentGroup.postValue(it)
+                }
+                .onFailure {
+                    setNetworkDialogEvent()
+                }
         }
     }
 
@@ -54,7 +62,21 @@ class MembersViewModel @Inject constructor(
                     async { membersRepository.getUserInfo(userId) }
                 }
             _membersList.postValue(
-                deferredMemberList.awaitAll().map { result -> result ?: return@launch })
+                deferredMemberList.awaitAll().map { result ->
+                    if (result.isSuccess) {
+                        result.getOrNull() ?: return@launch
+                    } else {
+                        val throwable = result.exceptionOrNull() ?: return@launch
+                        setNetworkDialogEvent()
+                        return@launch
+                    }
+                }
+            )
         }
+    }
+
+    private fun setNetworkDialogEvent() {
+        setLoadingEvent(false)
+        _networkDialogEvent.postValue(Event(true))
     }
 }

--- a/app/src/main/java/com/ariari/mowoori/ui/missions/MissionsFragment.kt
+++ b/app/src/main/java/com/ariari/mowoori/ui/missions/MissionsFragment.kt
@@ -103,7 +103,7 @@ class MissionsFragment : BaseFragment<FragmentMissionsBinding>(R.layout.fragment
         NetworkDialogFragment(object : NetworkDialogFragment.NetworkDialogListener {
             override fun onCancelClick(dialog: DialogFragment) {
                 dialog.dismiss()
-                findNavController().navigate(R.id.action_stampsFragment_to_homeFragment)
+                findNavController().navigate(R.id.action_missionsFragment_to_homeFragment)
             }
 
             override fun onRetryClick(dialog: DialogFragment) {

--- a/app/src/main/java/com/ariari/mowoori/ui/missions/MissionsFragment.kt
+++ b/app/src/main/java/com/ariari/mowoori/ui/missions/MissionsFragment.kt
@@ -31,6 +31,7 @@ class MissionsFragment : BaseFragment<FragmentMissionsBinding>(R.layout.fragment
         binding.lifecycleOwner = viewLifecycleOwner
         binding.viewModel = missionsViewModel
         setMissionsRvAdapter()
+        loadMissions()
         setObserver()
     }
 
@@ -53,6 +54,9 @@ class MissionsFragment : BaseFragment<FragmentMissionsBinding>(R.layout.fragment
 
     private fun setMissionsRvAdapter() {
         binding.rvMissions.adapter = missionsAdapter
+    }
+
+    private fun loadMissions() {
         if (requireContext().isNetWorkAvailable()) {
             missionsViewModel.setLoadingEvent(true)
             missionsViewModel.sendUserToLoadMissions(args.user)
@@ -108,7 +112,7 @@ class MissionsFragment : BaseFragment<FragmentMissionsBinding>(R.layout.fragment
 
             override fun onRetryClick(dialog: DialogFragment) {
                 dialog.dismiss()
-                missionsViewModel.sendUserToLoadMissions(args.user)
+                loadMissions()
             }
         }).show(requireActivity().supportFragmentManager, "NetworkDialogFragment")
     }

--- a/app/src/main/java/com/ariari/mowoori/ui/missions/MissionsViewModel.kt
+++ b/app/src/main/java/com/ariari/mowoori/ui/missions/MissionsViewModel.kt
@@ -55,7 +55,7 @@ class MissionsViewModel @Inject constructor(
     }
 
     private fun checkRequestCount() {
-        if (requestCount > 1) {
+        if (requestCount == 1) {
             setNetworkDialogEvent()
         }
     }

--- a/app/src/main/java/com/ariari/mowoori/ui/missionsadd/MissionsAddFragment.kt
+++ b/app/src/main/java/com/ariari/mowoori/ui/missionsadd/MissionsAddFragment.kt
@@ -211,7 +211,7 @@ class MissionsAddFragment :
         NetworkDialogFragment(object : NetworkDialogFragment.NetworkDialogListener {
             override fun onCancelClick(dialog: DialogFragment) {
                 dialog.dismiss()
-                findNavController().navigate(R.id.action_stampsFragment_to_homeFragment)
+                findNavController().navigate(R.id.action_missionsAddFragment_to_homeFragment)
             }
 
             override fun onRetryClick(dialog: DialogFragment) {

--- a/app/src/main/java/com/ariari/mowoori/ui/missionsadd/MissionsAddFragment.kt
+++ b/app/src/main/java/com/ariari/mowoori/ui/missionsadd/MissionsAddFragment.kt
@@ -109,15 +109,19 @@ class MissionsAddFragment :
         missionsAddViewModel.checkMissionValidEvent.observe(viewLifecycleOwner, {
             if (isMissionNameValid() && isMissionDateValid()) {
                 Timber.d("success")
-                if (requireContext().isNetWorkAvailable()) {
-                    missionsAddViewModel.postMission(binding.etMissionsAddWhat.text.toString())
-                } else {
-                    showNetworkDialog()
-                }
+                postMission()
             } else {
                 Timber.d("fail")
             }
         })
+    }
+
+    private fun postMission() {
+        if (requireContext().isNetWorkAvailable()) {
+            missionsAddViewModel.postMission(binding.etMissionsAddWhat.text.toString())
+        } else {
+            showNetworkDialog()
+        }
     }
 
     private fun setButtonListener() {
@@ -216,7 +220,7 @@ class MissionsAddFragment :
 
             override fun onRetryClick(dialog: DialogFragment) {
                 dialog.dismiss()
-                missionsAddViewModel.postMission(binding.etMissionsAddWhat.text.toString())
+                postMission()
             }
         }).show(requireActivity().supportFragmentManager, "NetworkDialogFragment")
     }

--- a/app/src/main/java/com/ariari/mowoori/ui/missionsadd/MissionsAddViewModel.kt
+++ b/app/src/main/java/com/ariari/mowoori/ui/missionsadd/MissionsAddViewModel.kt
@@ -57,7 +57,7 @@ class MissionsAddViewModel @Inject constructor(
     }
 
     private fun checkRequestCount() {
-        if (requestCount > 1) {
+        if (requestCount == 1) {
             setNetworkDialogEvent()
         }
     }

--- a/app/src/main/java/com/ariari/mowoori/ui/register/RegisterViewModel.kt
+++ b/app/src/main/java/com/ariari/mowoori/ui/register/RegisterViewModel.kt
@@ -39,8 +39,11 @@ class RegisterViewModel @Inject constructor(
 
     fun createNickName() {
         viewModelScope.launch(Dispatchers.IO) {
-            val nickname = introRepository.getRandomNickName()
-            profileText.postValue(nickname)
+            introRepository.getRandomNickName()
+                .onSuccess { nickname ->
+                    profileText.postValue(nickname)
+                }
+                .onFailure { }
         }
     }
 
@@ -52,7 +55,7 @@ class RegisterViewModel @Inject constructor(
         _profileImageUri.postValue(uri)
     }
 
-    fun setUserRegistered(isRegistered:Boolean){
+    fun setUserRegistered(isRegistered: Boolean) {
         introRepository.setUserRegistered(isRegistered)
     }
 

--- a/app/src/main/java/com/ariari/mowoori/ui/stamp/StampsViewModel.kt
+++ b/app/src/main/java/com/ariari/mowoori/ui/stamp/StampsViewModel.kt
@@ -58,7 +58,7 @@ class StampsViewModel @Inject constructor(
     }
 
     private fun checkRequestCount() {
-        if (requestCount > 1) {
+        if (requestCount == 1) {
             setNetworkDialogEvent()
         }
     }

--- a/app/src/main/java/com/ariari/mowoori/ui/stamp/StampsViewModel.kt
+++ b/app/src/main/java/com/ariari/mowoori/ui/stamp/StampsViewModel.kt
@@ -46,6 +46,23 @@ class StampsViewModel @Inject constructor(
     private val _networkDialogEvent = MutableLiveData<Event<Boolean>>()
     val networkDialogEvent: LiveData<Event<Boolean>> get() = _networkDialogEvent
 
+    private var _requestCount = 0
+    private val requestCount get() = _requestCount
+
+    private fun initRequestCount() {
+        _requestCount = 0
+    }
+
+    private fun addRequestCount() {
+        _requestCount++
+    }
+
+    private fun checkRequestCount() {
+        if (requestCount > 1) {
+            setNetworkDialogEvent()
+        }
+    }
+
     fun setLoadingEvent(flag: Boolean) {
         _loadingEvent.postValue(Event(flag))
     }
@@ -63,12 +80,14 @@ class StampsViewModel @Inject constructor(
         viewModelScope.launch(Dispatchers.IO) {
             val tempStampList = mutableListOf<Stamp>()
             missionInfo.stampList.forEach { stampId ->
+                initRequestCount()
                 stampsRepository.getStampInfo(stampId)
                     .onSuccess { stampInfo ->
                         tempStampList.add(Stamp(stampId, stampInfo))
                     }
                     .onFailure {
-                        setNetworkDialogEvent()
+                        addRequestCount()
+                        checkRequestCount()
                         Timber.e("stampInfo Error: $it")
                     }
             }
@@ -96,11 +115,13 @@ class StampsViewModel @Inject constructor(
 
     fun loadMissionInfo(missionId: String) {
         viewModelScope.launch(Dispatchers.IO) {
+            initRequestCount()
             missionsRepository.getMissionInfo(missionId)
                 .onSuccess {
                     _mission.postValue(Mission(missionId, it))
                 }.onFailure {
-                    setNetworkDialogEvent()
+                    addRequestCount()
+                    checkRequestCount()
                     Timber.e("$it")
                 }
         }
@@ -108,15 +129,19 @@ class StampsViewModel @Inject constructor(
 
     private fun setNetworkDialogEvent() {
         setLoadingEvent(false)
+
         _networkDialogEvent.postValue(Event(true))
     }
-    
+
     fun postFcm() {
-        LogUtil.log("fcm","fcm")
-        viewModelScope.launch {
+        LogUtil.log("fcm", "fcm")
+        viewModelScope.launch(Dispatchers.IO) {
+            initRequestCount()
             stampsRepository.postFcmMessage().onSuccess {
                 LogUtil.log("fcm", it.success.toString())
             }.onFailure {
+                addRequestCount()
+                checkRequestCount()
                 LogUtil.log("fcm", it.message.toString())
             }
         }

--- a/app/src/main/java/com/ariari/mowoori/ui/stamp_detail/StampDetailFragment.kt
+++ b/app/src/main/java/com/ariari/mowoori/ui/stamp_detail/StampDetailFragment.kt
@@ -315,7 +315,7 @@ class StampDetailFragment :
         NetworkDialogFragment(object : NetworkDialogFragment.NetworkDialogListener {
             override fun onCancelClick(dialog: DialogFragment) {
                 dialog.dismiss()
-                findNavController().navigate(R.id.action_stampsFragment_to_homeFragment)
+                findNavController().navigate(R.id.action_stampDetailFragment_to_homeFragment)
             }
 
             override fun onRetryClick(dialog: DialogFragment) {

--- a/app/src/main/java/com/ariari/mowoori/ui/stamp_detail/StampDetailViewModel.kt
+++ b/app/src/main/java/com/ariari/mowoori/ui/stamp_detail/StampDetailViewModel.kt
@@ -65,7 +65,7 @@ class StampDetailViewModel @Inject constructor(
     }
 
     private fun checkRequestCount() {
-        if (requestCount > 1) {
+        if (requestCount == 1) {
             setNetworkDialogEvent()
         }
     }

--- a/app/src/main/res/navigation/main_navigation.xml
+++ b/app/src/main/res/navigation/main_navigation.xml
@@ -26,6 +26,11 @@
         <action
             android:id="@+id/action_membersFragment_to_missionsFragment"
             app:destination="@id/missionsFragment" />
+        <action
+            android:id="@+id/action_membersFragment_to_homeFragment"
+            app:destination="@id/homeFragment"
+            app:popUpTo="@id/homeFragment"
+            app:popUpToInclusive="true" />
     </fragment>
     <fragment
         android:id="@+id/missionsFragment"
@@ -43,6 +48,11 @@
         <action
             android:id="@+id/action_missionsFragment_to_stampsFragment"
             app:destination="@id/stampsFragment" />
+        <action
+            android:id="@+id/action_missionsFragment_to_homeFragment"
+            app:destination="@id/homeFragment"
+            app:popUpTo="@id/homeFragment"
+            app:popUpToInclusive="true" />
     </fragment>
     <fragment
         android:id="@+id/inviteCheckFragment"
@@ -76,7 +86,13 @@
         android:id="@+id/missionsAddFragment"
         android:name="com.ariari.mowoori.ui.missionsadd.MissionsAddFragment"
         android:label="MissionsAddFragment"
-        tools:layout="@layout/fragment_missions_add" />
+        tools:layout="@layout/fragment_missions_add" >
+        <action
+            android:id="@+id/action_missionsAddFragment_to_homeFragment"
+            app:destination="@id/homeFragment"
+            app:popUpTo="@id/homeFragment"
+            app:popUpToInclusive="true" />
+    </fragment>
     <fragment
         android:id="@+id/stampsFragment"
         android:name="com.ariari.mowoori.ui.stamp.StampsFragment"
@@ -105,6 +121,11 @@
         <argument
             android:name="detailInfo"
             app:argType="com.ariari.mowoori.ui.stamp.entity.DetailInfo" />
+        <action
+            android:id="@+id/action_stampDetailFragment_to_homeFragment"
+            app:destination="@id/homeFragment"
+            app:popUpTo="@id/homeFragment"
+            app:popUpToInclusive="true" />
     </fragment>
 
 </navigation>


### PR DESCRIPTION
# ❗️ 이슈 트래킹
- #104 

# 💡 작업목록
- 그룹 생성/참여 화면, 구성원 화면 네트워크 연결 분기 처리
- 네트워크 요청 최초 실패 시에만 다이얼로그 생성

# ❓ 고민과 해결
- 파이어베이스 연결 요청 실패 시 경우에 따라 2번 요청하는 경우가 있고 1번만 요청하는 경우가 있어 최초 한번만 실패했을 때 다이얼로그를 띄어주도록 구현했다.

