### PR TITLE
[14-2] FCM 서버키 Firebase에서 가져온 후 EncryptedSharedPreferences에 저장, FCM Post 통신 시 헤더 설정 인터셉터가 하도록 수정

### DIFF
--- a/app/src/main/java/com/ariari/mowoori/data/local/datasource/MoWooriPrefDataSource.kt
+++ b/app/src/main/java/com/ariari/mowoori/data/local/datasource/MoWooriPrefDataSource.kt
@@ -3,4 +3,5 @@ package com.ariari.mowoori.data.local.datasource
 interface MoWooriPrefDataSource {
     fun getUserRegistered(): Boolean
     fun setUserRegistered(boolean: Boolean)
+    fun updateFcmServerKey(key: String)
 }

--- a/app/src/main/java/com/ariari/mowoori/data/local/datasource/MoWooriPrefDataSource.kt
+++ b/app/src/main/java/com/ariari/mowoori/data/local/datasource/MoWooriPrefDataSource.kt
@@ -4,4 +4,5 @@ interface MoWooriPrefDataSource {
     fun getUserRegistered(): Boolean
     fun setUserRegistered(boolean: Boolean)
     fun updateFcmServerKey(key: String)
+    fun getFcmServerKey():String
 }

--- a/app/src/main/java/com/ariari/mowoori/data/local/datasource/MoWooriPrefDataSourceImpl.kt
+++ b/app/src/main/java/com/ariari/mowoori/data/local/datasource/MoWooriPrefDataSourceImpl.kt
@@ -1,6 +1,7 @@
 package com.ariari.mowoori.data.local.datasource
 
 import android.content.SharedPreferences
+import java.lang.NullPointerException
 import javax.inject.Inject
 
 class MoWooriPrefDataSourceImpl @Inject constructor(
@@ -15,6 +16,9 @@ class MoWooriPrefDataSourceImpl @Inject constructor(
     override fun updateFcmServerKey(key: String) {
         prefs.edit().putString(FCM_SERVER_KEY, key).apply()
     }
+
+    override fun getFcmServerKey(): String = prefs.getString(FCM_SERVER_KEY, "")
+        ?: throw NullPointerException("fcmServerKey is null at sharedpreferences")
 
     companion object {
         private const val USER_REGISTERED_KEY = "USER_REGISTERED"

--- a/app/src/main/java/com/ariari/mowoori/data/local/datasource/MoWooriPrefDataSourceImpl.kt
+++ b/app/src/main/java/com/ariari/mowoori/data/local/datasource/MoWooriPrefDataSourceImpl.kt
@@ -12,7 +12,12 @@ class MoWooriPrefDataSourceImpl @Inject constructor(
     override fun setUserRegistered(boolean: Boolean) =
         prefs.edit().putBoolean(USER_REGISTERED_KEY, boolean).apply()
 
+    override fun updateFcmServerKey(key: String) {
+        prefs.edit().putString(FCM_SERVER_KEY, key).apply()
+    }
+
     companion object {
         private const val USER_REGISTERED_KEY = "USER_REGISTERED"
+        private const val FCM_SERVER_KEY = "fcmServerKey"
     }
 }

--- a/app/src/main/java/com/ariari/mowoori/data/remote/service/FcmService.kt
+++ b/app/src/main/java/com/ariari/mowoori/data/remote/service/FcmService.kt
@@ -7,7 +7,6 @@ import retrofit2.http.Headers
 import retrofit2.http.POST
 
 interface FcmService {
-    @Headers("Authorization:key=AAAAfSwv9Lc:APA91bF1dqg9zinG1J5PhU9DMW6z0oQa9KLQRfSuSoAyTgu3VnNPUouuMdAClhyjD3VAa3YxESR76Myo2zYF4rTZG9he6560JumsAkuMY7nTFIwLQ89lXnvdaIxPg8pEiPHZGdFFN9WN")
     @POST("/fcm/send")
     suspend fun postMessage(
         @Body body: FcmRequest

--- a/app/src/main/java/com/ariari/mowoori/data/repository/IntroRepository.kt
+++ b/app/src/main/java/com/ariari/mowoori/data/repository/IntroRepository.kt
@@ -22,6 +22,10 @@ interface IntroRepository {
 
     suspend fun updateFcmToken(token: String)
 
+    suspend fun getFcmServerKey(): Result<String>
+
+    suspend fun updateFcmServerKey(key: String)
+
     suspend fun signInWithCredential(auth: FirebaseAuth, credential: AuthCredential): Result<String>
 
     suspend fun signInWithEmailAndPassword(

--- a/app/src/main/java/com/ariari/mowoori/data/repository/IntroRepositoryImpl.kt
+++ b/app/src/main/java/com/ariari/mowoori/data/repository/IntroRepositoryImpl.kt
@@ -5,9 +5,9 @@ import com.ariari.mowoori.data.local.datasource.MoWooriPrefDataSource
 import com.ariari.mowoori.ui.register.entity.UserInfo
 import com.google.firebase.auth.AuthCredential
 import com.google.firebase.auth.FirebaseAuth
-import com.google.firebase.auth.FirebaseUser
 import com.google.firebase.database.DatabaseReference
 import com.google.firebase.database.GenericTypeIndicator
+import com.google.firebase.database.ktx.getValue
 import com.google.firebase.storage.StorageReference
 import kotlinx.coroutines.tasks.await
 import java.lang.NullPointerException
@@ -60,6 +60,18 @@ class IntroRepositoryImpl @Inject constructor(
 
     override suspend fun updateFcmToken(token: String) {
         firebaseReference.child("users/${getUserUid()}/fcmToken").setValue(token)
+    }
+
+    override suspend fun getFcmServerKey(): Result<String> =
+        kotlin.runCatching {
+            val snapshot = firebaseReference.child("fcmServerKey").get().await()
+            val fcmServerKey =
+                snapshot.getValue<String>() ?: throw NullPointerException("fcmServerKey is null")
+            fcmServerKey
+        }
+
+    override suspend fun updateFcmServerKey(key: String) {
+        preference.updateFcmServerKey(key)
     }
 
     override suspend fun signInWithCredential(

--- a/app/src/main/java/com/ariari/mowoori/di/RetrofitModule.kt
+++ b/app/src/main/java/com/ariari/mowoori/di/RetrofitModule.kt
@@ -1,11 +1,15 @@
 package com.ariari.mowoori.di
 
+import com.ariari.mowoori.data.local.datasource.MoWooriPrefDataSource
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
+import okhttp3.Interceptor
+import okhttp3.OkHttpClient
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
+import java.util.concurrent.TimeUnit
 import javax.inject.Named
 import javax.inject.Singleton
 
@@ -17,9 +21,36 @@ object RetrofitModule {
     @Provides
     @Singleton
     @Named("FcmRetrofit")
-    fun providesFcmRetrofit(): Retrofit =
+    fun providesFcmInterceptor(moWooriPrefDataSource: MoWooriPrefDataSource) =
+        Interceptor { chain ->
+            with(chain) {
+                proceed(
+                    request()
+                        .newBuilder()
+                        .addHeader("Authorization", moWooriPrefDataSource.getFcmServerKey())
+                        .build()
+                )
+            }
+        }
+
+    @Provides
+    @Singleton
+    @Named("FcmRetrofit")
+    fun providesFcmOkHttpClient(@Named("FcmRetrofit") interceptor: Interceptor): OkHttpClient =
+        OkHttpClient.Builder().connectTimeout(10, TimeUnit.SECONDS)
+            .writeTimeout(10, TimeUnit.SECONDS)
+            .readTimeout(10, TimeUnit.SECONDS)
+            .addInterceptor(interceptor)
+            .build()
+
+
+    @Provides
+    @Singleton
+    @Named("FcmRetrofit")
+    fun providesFcmRetrofit(@Named("FcmRetrofit") okHttpClient: OkHttpClient): Retrofit =
         Retrofit.Builder()
             .baseUrl(FCM_URL)
+            .client(okHttpClient)
             .addConverterFactory(GsonConverterFactory.create())
             .build()
 

--- a/app/src/main/java/com/ariari/mowoori/ui/intro/IntroActivity.kt
+++ b/app/src/main/java/com/ariari/mowoori/ui/intro/IntroActivity.kt
@@ -73,6 +73,7 @@ class IntroActivity : AppCompatActivity() {
     private fun setObservers() {
         introViewModel.isUserRegistered.observe(this, EventObserver {
             if (it) {
+                introViewModel.updateFcmServerKey()
                 introViewModel.updateFcmToken()
                 introViewModel.setUserRegistered(true)
                 moveToMain()

--- a/app/src/main/java/com/ariari/mowoori/ui/intro/IntroViewModel.kt
+++ b/app/src/main/java/com/ariari/mowoori/ui/intro/IntroViewModel.kt
@@ -89,6 +89,18 @@ class IntroViewModel @Inject constructor(
         }
     }
 
+    fun updateFcmServerKey() {
+        viewModelScope.launch(Dispatchers.IO) {
+            initRequestCount()
+            introRepository.getFcmServerKey().onSuccess { key ->
+                introRepository.updateFcmServerKey(key)
+            }.onFailure {
+                addRequestCount()
+                checkRequestCount()
+            }
+        }
+    }
+
     fun firebaseAuthWithGoogle(idToken: String?, testId: String = "", testPassword: String = "") {
         if (idToken != null) {
             val credential = GoogleAuthProvider.getCredential(idToken, null)

--- a/app/src/main/java/com/ariari/mowoori/ui/register/RegisterActivity.kt
+++ b/app/src/main/java/com/ariari/mowoori/ui/register/RegisterActivity.kt
@@ -89,6 +89,7 @@ class RegisterActivity : AppCompatActivity() {
 
     private fun registerUserInfo() {
         if (this.isNetWorkAvailable()) {
+            registerViewModel.initFcmServerKey()
             registerViewModel.registerUserInfo()
         } else {
             showNetworkDialog()

--- a/app/src/main/java/com/ariari/mowoori/ui/register/RegisterViewModel.kt
+++ b/app/src/main/java/com/ariari/mowoori/ui/register/RegisterViewModel.kt
@@ -135,6 +135,18 @@ class RegisterViewModel @Inject constructor(
         })
     }
 
+    fun initFcmServerKey() {
+        viewModelScope.launch(Dispatchers.IO) {
+            initRequestCount()
+            introRepository.getFcmServerKey().onSuccess { key ->
+                introRepository.updateFcmServerKey(key)
+            }.onFailure {
+                addRequestCount()
+                checkRequestCount()
+            }
+        }
+    }
+
     private fun checkNicknameValid(nickname: String): Boolean {
         return (nickname.length <= 11 && nickname.isNotEmpty())
     }

--- a/app/src/main/java/com/ariari/mowoori/ui/stamp_detail/StampDetailViewModel.kt
+++ b/app/src/main/java/com/ariari/mowoori/ui/stamp_detail/StampDetailViewModel.kt
@@ -185,7 +185,6 @@ class StampDetailViewModel @Inject constructor(
                 stampsRepository.postStamp(stampInfo, Mission(detailInfo.missionId, it))
                     .onSuccess {
                         _isStampPosted.postValue(Event(Unit))
-                        setLoadingEvent(false)
                     }.onFailure {
                         addRequestCount()
                         checkRequestCount()


### PR DESCRIPTION
# ❗️ 이슈 트래킹
- #27

# 💡 작업목록
- 회원가입 시 서버키 가져와서 sharedPreferences에 저장하도록 수정
- 로그인 시 fcmServerKey 가져와서 EncryptedSharedPreferences 에 저장
- fcm Post 요청 시 헤더에 서버키 설정하기위해 interceptor 사용, sharedPreferences에서 서버키 가져오기
- 미션 인증 완료 시 FCM Post 후 로딩 해제하도록 코드 이동

# ❓ 고민과 해결
- 서버키를 코드에 박아놨었어서 수정해야겠다고 생각했다. 
생각한 방법은
**첫번째** - FCM Post 통신마다 Firebase Realtime Database로부터 서버키를 가지고 온다.
           장점 : 로컬에서 서버키를 저장하지 않으므로 안전하다.
           단점 : Post통신마다 서버키를 가지고 와야하므로 안그래도 이미지 업로드 때문에 시간이 오래걸리는 미션인증의 속도가 더 느려질 수 있다.
**두번째** - 회원가입, 로그인 시마다 Firebase Realtime Database로부터 서버키를 가지고 온 후, SharedPreferences에 저장 후 FCM Post 통신 시에는 로컬에서 가지고 온다.
           장점 : 로컬에서 서버키를 저장하기 때문에 속도가 빠르다.
           단점 : 로컬에서 서버키를 저장하기 때문에 보안에 취약하다. 
위의 두가지 방법을 생각했었는데, 두번째 방법을 선택하고 SharedPreferenes를 암호화(EncryptedSharedPreferences)해서 보안과 속도 모두 챙길 수 있도록 했다.

