### PR TITLE
[25-1] 네트워크 에러 핸들링

### DIFF
--- a/app/src/main/java/com/ariari/mowoori/MoWooriApp.kt
+++ b/app/src/main/java/com/ariari/mowoori/MoWooriApp.kt
@@ -1,10 +1,6 @@
 package com.ariari.mowoori
 
 import android.app.Application
-import android.content.Context
-import android.net.ConnectivityManager
-import com.ariari.mowoori.util.NetworkCallBack
-import com.ariari.mowoori.util.toastMessage
 import com.google.firebase.FirebaseApp
 import dagger.hilt.android.HiltAndroidApp
 import timber.log.Timber
@@ -15,22 +11,5 @@ class MoWooriApp : Application() {
         super.onCreate()
         Timber.plant(Timber.DebugTree())
         FirebaseApp.initializeApp(this)
-        registerNetworkCallback()
-    }
-
-    override fun onTerminate() {
-        super.onTerminate()
-        unRegisterNetworkCallback()
-    }
-
-    private fun registerNetworkCallback() {
-        (getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager)
-            .registerNetworkCallback(NetworkCallBack.networkRequest, NetworkCallBack)
-        NetworkCallBack.setDoCellularChanged { applicationContext.toastMessage("모바일 데이터에 연결되었습니다.") }
-    }
-
-    private fun unRegisterNetworkCallback() {
-        (getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager)
-            .unregisterNetworkCallback(NetworkCallBack)
     }
 }

--- a/app/src/main/java/com/ariari/mowoori/data/repository/GroupRepository.kt
+++ b/app/src/main/java/com/ariari/mowoori/data/repository/GroupRepository.kt
@@ -2,7 +2,6 @@ package com.ariari.mowoori.data.repository
 
 import com.ariari.mowoori.ui.home.entity.GroupInfo
 import com.ariari.mowoori.ui.register.entity.User
-import com.ariari.mowoori.ui.register.entity.UserInfo
 
 
 interface GroupRepository {
@@ -14,5 +13,5 @@ interface GroupRepository {
 
     suspend fun getUser(): Result<User>
 
-    suspend fun isExistGroupId(groupId: String): Boolean
+    suspend fun isExistGroupId(groupId: String): Result<Boolean>
 }

--- a/app/src/main/java/com/ariari/mowoori/data/repository/IntroRepositoryImpl.kt
+++ b/app/src/main/java/com/ariari/mowoori/data/repository/IntroRepositoryImpl.kt
@@ -3,14 +3,13 @@ package com.ariari.mowoori.data.repository
 import android.net.Uri
 import com.ariari.mowoori.data.local.datasource.MoWooriPrefDataSource
 import com.ariari.mowoori.ui.register.entity.UserInfo
+import com.ariari.mowoori.util.ErrorMessage
 import com.google.firebase.auth.AuthCredential
 import com.google.firebase.auth.FirebaseAuth
-import com.google.firebase.auth.FirebaseUser
 import com.google.firebase.database.DatabaseReference
 import com.google.firebase.database.GenericTypeIndicator
 import com.google.firebase.storage.StorageReference
 import kotlinx.coroutines.tasks.await
-import java.lang.NullPointerException
 import javax.inject.Inject
 
 class IntroRepositoryImpl @Inject constructor(
@@ -34,9 +33,9 @@ class IntroRepositoryImpl @Inject constructor(
         val namesRef = firebaseReference.child("names").get().await()
         val map =
             namesRef.getValue(object : GenericTypeIndicator<HashMap<String, List<String>>>() {})
-                ?: throw NullPointerException("invalid path")
-        val prefixList = map["prefix"] ?: throw NullPointerException("invalid key")
-        val nameList = map["name"] ?: throw NullPointerException("invalid key")
+                ?: throw NullPointerException(ErrorMessage.Path.message)
+        val prefixList = map["prefix"] ?: throw NullPointerException(ErrorMessage.HashKey.message)
+        val nameList = map["name"] ?: throw NullPointerException(ErrorMessage.HashKey.message)
         "${prefixList.random()} ${nameList.random()}"
     }
 
@@ -45,7 +44,7 @@ class IntroRepositoryImpl @Inject constructor(
     }
 
     override suspend fun userRegister(userInfo: UserInfo): Result<Boolean> = runCatching {
-        val uid = getUserUid() ?: throw NullPointerException("uid is null")
+        val uid = getUserUid() ?: throw NullPointerException(ErrorMessage.Uid.message)
         firebaseReference.child("users").child(uid).setValue(userInfo)
         true
     }
@@ -67,7 +66,7 @@ class IntroRepositoryImpl @Inject constructor(
         credential: AuthCredential,
     ): Result<String> = kotlin.runCatching {
         val authResult = auth.signInWithCredential(credential).await()
-        authResult.user?.uid ?: throw NullPointerException("uid is null")
+        authResult.user?.uid ?: throw NullPointerException(ErrorMessage.Uid.message)
     }
 
     override suspend fun signInWithEmailAndPassword(

--- a/app/src/main/java/com/ariari/mowoori/data/repository/MembersRepositoryImpl.kt
+++ b/app/src/main/java/com/ariari/mowoori/data/repository/MembersRepositoryImpl.kt
@@ -4,6 +4,7 @@ import com.ariari.mowoori.ui.home.entity.Group
 import com.ariari.mowoori.ui.home.entity.GroupInfo
 import com.ariari.mowoori.ui.register.entity.User
 import com.ariari.mowoori.ui.register.entity.UserInfo
+import com.ariari.mowoori.util.ErrorMessage
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.database.DatabaseReference
 import kotlinx.coroutines.tasks.await
@@ -14,14 +15,14 @@ class MembersRepositoryImpl @Inject constructor(
     private val firebaseAuth: FirebaseAuth,
 ) : MembersRepository {
     override suspend fun getCurrentGroupInfo(): Result<Group> = kotlin.runCatching {
-        val uid = getUserUid() ?: throw NullPointerException("uid is null")
+        val uid = getUserUid() ?: throw NullPointerException(ErrorMessage.Uid.message)
         val groupIdSnapshot = databaseReference.child("users/$uid/currentGroupId").get().await()
         val currentGroupId = groupIdSnapshot.getValue(String::class.java)
-            ?: throw NullPointerException("groupId is null")
+            ?: throw NullPointerException(ErrorMessage.GroupId.message)
 
         val groupInfoSnapshot = databaseReference.child("groups/$currentGroupId").get().await()
         val group = groupInfoSnapshot.getValue(GroupInfo::class.java) ?: throw NullPointerException(
-            "groupInfo is null"
+            ErrorMessage.GroupInfo.message
         )
         Group(currentGroupId, group)
     }

--- a/app/src/main/java/com/ariari/mowoori/data/repository/MembersRepositoryImpl.kt
+++ b/app/src/main/java/com/ariari/mowoori/data/repository/MembersRepositoryImpl.kt
@@ -18,7 +18,7 @@ class MembersRepositoryImpl @Inject constructor(
         val uid = getUserUid() ?: throw NullPointerException(ErrorMessage.Uid.message)
         val groupIdSnapshot = databaseReference.child("users/$uid/currentGroupId").get().await()
         val currentGroupId = groupIdSnapshot.getValue(String::class.java)
-            ?: throw NullPointerException(ErrorMessage.GroupId.message)
+            ?: throw NullPointerException(ErrorMessage.CurrentGroupId.message)
 
         val groupInfoSnapshot = databaseReference.child("groups/$currentGroupId").get().await()
         val group = groupInfoSnapshot.getValue(GroupInfo::class.java) ?: throw NullPointerException(
@@ -32,9 +32,9 @@ class MembersRepositoryImpl @Inject constructor(
     override suspend fun getUserInfo(userId: String): Result<User> =
         kotlin.runCatching {
             val userSnapshot = databaseReference.child("users/$userId").get().await()
-            User(
-                userId,
-                userSnapshot.getValue(UserInfo::class.java) ?: UserInfo()
-            )
+            val userInfo =
+                userSnapshot.getValue(UserInfo::class.java) ?: throw NullPointerException(
+                    ErrorMessage.UserInfo.message)
+            User(userId, userInfo)
         }
 }

--- a/app/src/main/java/com/ariari/mowoori/data/repository/MissionsRepositoryImpl.kt
+++ b/app/src/main/java/com/ariari/mowoori/data/repository/MissionsRepositoryImpl.kt
@@ -15,7 +15,7 @@ import javax.inject.Inject
 
 class MissionsRepositoryImpl @Inject constructor(
     private val firebaseReference: DatabaseReference,
-    private val firebaseAuth: FirebaseAuth
+    private val firebaseAuth: FirebaseAuth,
 ) : MissionsRepository {
 
     override suspend fun getMissionIdList(groupId: String): Result<List<String>> = runCatching {
@@ -51,7 +51,7 @@ class MissionsRepositoryImpl @Inject constructor(
         val uid = firebaseAuth.currentUser?.uid ?: throw NullPointerException("uid is null")
         val snapshot = firebaseReference.child("users/$uid").get().await()
         val userInfo = snapshot.getValue(UserInfo::class.java)
-            ?: throw NullPointerException("userInfo is null")
+            ?: throw NullPointerException(ErrorMessage.UserInfo.message)
         User(uid, userInfo)
     }
 
@@ -72,7 +72,7 @@ class MissionsRepositoryImpl @Inject constructor(
     override suspend fun postMission(
         missionInfo: MissionInfo,
         groupId: String,
-        missionIdList: List<String>
+        missionIdList: List<String>,
     ) {
         val missionId = firebaseReference.child("missions").push().key
         missionId?.let {
@@ -92,6 +92,6 @@ class MissionsRepositoryImpl @Inject constructor(
     override suspend fun getUserName(userId: String): Result<String> = kotlin.runCatching {
         val snapshot = firebaseReference.child("users").child(userId).get().await()
         val userInfo = snapshot.getValue(UserInfo::class.java)
-        userInfo?.nickname ?: throw NullPointerException("getUserName is null")
+        userInfo?.nickname ?: throw NullPointerException(ErrorMessage.UserInfo.message)
     }
 }

--- a/app/src/main/java/com/ariari/mowoori/data/repository/MissionsRepositoryImpl.kt
+++ b/app/src/main/java/com/ariari/mowoori/data/repository/MissionsRepositoryImpl.kt
@@ -4,6 +4,7 @@ import com.ariari.mowoori.ui.missions.entity.Mission
 import com.ariari.mowoori.ui.missions.entity.MissionInfo
 import com.ariari.mowoori.ui.register.entity.User
 import com.ariari.mowoori.ui.register.entity.UserInfo
+import com.ariari.mowoori.util.ErrorMessage
 import com.ariari.mowoori.util.LogUtil
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.database.DatabaseReference
@@ -59,7 +60,7 @@ class MissionsRepositoryImpl @Inject constructor(
             val snapshot = firebaseReference.child("missions/$missionId").get().await()
             LogUtil.log("getMission Impl", snapshot.getValue(MissionInfo::class.java).toString())
             val missionInfo = snapshot.getValue(MissionInfo::class.java)
-                ?: throw NullPointerException("mission is null")
+                ?: throw NullPointerException(ErrorMessage.MissionInfo.message)
             missionInfo
         }
 

--- a/app/src/main/java/com/ariari/mowoori/data/repository/StampsRepositoryImpl.kt
+++ b/app/src/main/java/com/ariari/mowoori/data/repository/StampsRepositoryImpl.kt
@@ -9,6 +9,7 @@ import com.ariari.mowoori.ui.missions.entity.Mission
 import com.ariari.mowoori.ui.missions.entity.MissionInfo
 import com.ariari.mowoori.ui.stamp.entity.DetailInfo
 import com.ariari.mowoori.ui.stamp.entity.StampInfo
+import com.ariari.mowoori.util.ErrorMessage
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.database.DatabaseReference
 import com.google.firebase.database.ktx.getValue
@@ -27,7 +28,7 @@ class StampsRepositoryImpl @Inject constructor(
     override suspend fun getStampInfo(stampId: String): Result<StampInfo> = kotlin.runCatching {
         val snapshot = databaseReference.child("stamps/$stampId").get().await()
         snapshot.getValue(StampInfo::class.java)
-            ?: throw NullPointerException("getStampInfo is null")
+            ?: throw NullPointerException(ErrorMessage.StampInfo.message)
     }
 
     override fun getUserId(): Result<String> = kotlin.runCatching {

--- a/app/src/main/java/com/ariari/mowoori/data/repository/StampsRepositoryImpl.kt
+++ b/app/src/main/java/com/ariari/mowoori/data/repository/StampsRepositoryImpl.kt
@@ -22,7 +22,7 @@ class StampsRepositoryImpl @Inject constructor(
     private val databaseReference: DatabaseReference,
     private val storageReference: StorageReference,
     private val firebaseAuth: FirebaseAuth,
-    private val fcmDataSource: FcmDataSource
+    private val fcmDataSource: FcmDataSource,
 ) : StampsRepository {
 
     override suspend fun getStampInfo(stampId: String): Result<StampInfo> = kotlin.runCatching {
@@ -32,7 +32,8 @@ class StampsRepositoryImpl @Inject constructor(
     }
 
     override fun getUserId(): Result<String> = kotlin.runCatching {
-        val user = firebaseAuth.currentUser ?: throw throw NullPointerException("getUserId is null")
+        val user =
+            firebaseAuth.currentUser ?: throw throw NullPointerException(ErrorMessage.Uid.message)
         user.uid
     }
 
@@ -51,14 +52,14 @@ class StampsRepositoryImpl @Inject constructor(
                 )
                 databaseReference.updateChildren(childUpdates)
                 newId
-            } ?: throw NullPointerException("Couldn't get push key for posts")
+            } ?: throw NullPointerException(ErrorMessage.PushKey.message)
         }
 
     override suspend fun getMissionInfo(missionId: String): Result<MissionInfo> =
         kotlin.runCatching {
             val snapshot = databaseReference.child("missions/$missionId").get().await()
             snapshot.getValue(MissionInfo::class.java)
-                ?: throw NullPointerException("getMissionInfo is null")
+                ?: throw NullPointerException(ErrorMessage.MissionInfo.message)
         }
 
     override suspend fun putCertificationImage(uri: Uri, missionId: String): Result<String> =
@@ -79,7 +80,7 @@ class StampsRepositoryImpl @Inject constructor(
 
     override suspend fun postFcmMessage(
         fcmToken: String,
-        detailInfo: DetailInfo
+        detailInfo: DetailInfo,
     ): Result<FcmResponse> =
         kotlin.runCatching {
             fcmDataSource.postFcmMessage(
@@ -100,13 +101,14 @@ class StampsRepositoryImpl @Inject constructor(
 
     override suspend fun getGroupMembersUserId(): Result<List<String>> =
         kotlin.runCatching {
-            val uid = getUserId().getOrNull() ?: throw NullPointerException("userId is null")
+            val uid =
+                getUserId().getOrNull() ?: throw NullPointerException(ErrorMessage.Uid.message)
             val groupIdSnapshot = databaseReference.child("users/$uid/currentGroupId").get().await()
             val groupId = groupIdSnapshot.getValue<String>()
-                ?: throw NullPointerException("currentGroupId is null")
+                ?: throw NullPointerException(ErrorMessage.CurrentGroupId.message)
             val userListSnapshot = databaseReference.child("groups/$groupId/userList").get().await()
             val userList = userListSnapshot.getValue<MutableList<String>>()
-                ?: throw NullPointerException("userList is null")
+                ?: throw NullPointerException(ErrorMessage.UserList.message)
             userList.remove(uid)
             userList
         }

--- a/app/src/main/java/com/ariari/mowoori/ui/group/GroupFragment.kt
+++ b/app/src/main/java/com/ariari/mowoori/ui/group/GroupFragment.kt
@@ -16,8 +16,8 @@ import androidx.navigation.fragment.navArgs
 import com.ariari.mowoori.R
 import com.ariari.mowoori.databinding.FragmentGroupBinding
 import com.ariari.mowoori.ui.group.entity.GroupMode
+import com.ariari.mowoori.util.EventObserver
 import com.ariari.mowoori.util.isNetWorkAvailable
-import com.ariari.mowoori.util.toastMessage
 import com.ariari.mowoori.widget.NetworkDialogFragment
 import dagger.hilt.android.AndroidEntryPoint
 
@@ -80,13 +80,8 @@ class GroupFragment : Fragment() {
     }
 
     private fun setAddGroupCompleteObserver() {
-        viewModel.addGroupCompleteEvent.observe(viewLifecycleOwner, {
-            val newGroupId = it.peekContent()
-            if (newGroupId.isNotEmpty()) {
-                findNavController().navigate(R.id.action_groupNameFragment_to_homeFragment)
-            } else {
-                toastMessage("그룹 생성에 실패하였습니다.")
-            }
+        viewModel.addGroupCompleteEvent.observe(viewLifecycleOwner, EventObserver {
+            findNavController().navigate(R.id.action_groupNameFragment_to_homeFragment)
         })
     }
 

--- a/app/src/main/java/com/ariari/mowoori/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/com/ariari/mowoori/ui/home/HomeViewModel.kt
@@ -104,9 +104,9 @@ class HomeViewModel @Inject constructor(
 
     private fun setSnowmanLevel(doneMission: Int): SnowmanLevel {
         return when {
-            doneMission <= 1 -> SnowmanLevel.LV1
-            doneMission == 2 -> SnowmanLevel.LV2
-            doneMission == 3 -> SnowmanLevel.LV3
+            doneMission <= 0 -> SnowmanLevel.LV1
+            doneMission == 1 -> SnowmanLevel.LV2
+            doneMission == 2 -> SnowmanLevel.LV3
             else -> SnowmanLevel.LV4
         }
     }

--- a/app/src/main/java/com/ariari/mowoori/ui/intro/IntroViewModel.kt
+++ b/app/src/main/java/com/ariari/mowoori/ui/intro/IntroViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.ariari.mowoori.data.repository.IntroRepository
+import com.ariari.mowoori.util.ErrorMessage
 import com.ariari.mowoori.util.Event
 import com.google.android.gms.tasks.OnCompleteListener
 import com.google.firebase.auth.FirebaseAuth
@@ -68,8 +69,7 @@ class IntroViewModel @Inject constructor(
                     _isUserRegistered.postValue(Event(it))
                 }
                 .onFailure {
-                    addRequestCount()
-                    checkRequestCount()
+                    checkThrowableMessage(it)
                 }
         }
     }
@@ -99,9 +99,7 @@ class IntroViewModel @Inject constructor(
                         checkUserRegistered(uid)
                     }
                     .onFailure {
-                        // TODO: uid is null
-                        addRequestCount()
-                        checkRequestCount()
+                        checkThrowableMessage(it)
                     }
             }
         } else {
@@ -115,6 +113,16 @@ class IntroViewModel @Inject constructor(
                         _isTestLoginSuccess.postValue(false)
                     }
             }
+        }
+    }
+
+    private fun checkThrowableMessage(throwable: Throwable) {
+        when (throwable.message) {
+            ErrorMessage.Offline.message -> {
+                addRequestCount()
+                checkRequestCount()
+            }
+            else -> Unit
         }
     }
 

--- a/app/src/main/java/com/ariari/mowoori/ui/members/MembersViewModel.kt
+++ b/app/src/main/java/com/ariari/mowoori/ui/members/MembersViewModel.kt
@@ -100,13 +100,7 @@ class MembersViewModel @Inject constructor(
                 addRequestCount()
                 checkRequestCount()
             }
-            ErrorMessage.Uid.message -> {
-            }
-            ErrorMessage.GroupId.message -> {
-            }
-            ErrorMessage.GroupInfo.message -> {
-            }
-            else -> Unit
+            else -> setLoadingEvent(false)
         }
     }
 

--- a/app/src/main/java/com/ariari/mowoori/ui/missionsadd/MissionsAddViewModel.kt
+++ b/app/src/main/java/com/ariari/mowoori/ui/missionsadd/MissionsAddViewModel.kt
@@ -7,6 +7,7 @@ import androidx.lifecycle.viewModelScope
 import com.ariari.mowoori.data.repository.MissionsRepository
 import com.ariari.mowoori.ui.missions.entity.MissionInfo
 import com.ariari.mowoori.ui.register.entity.User
+import com.ariari.mowoori.util.ErrorMessage
 import com.ariari.mowoori.util.Event
 import com.ariari.mowoori.util.LogUtil
 import com.ariari.mowoori.util.getCurrentDate
@@ -78,8 +79,7 @@ class MissionsAddViewModel @Inject constructor(
             missionsRepository.getUser().onSuccess { user ->
                 loadMissionIdList(getMissionInfo(user.userId, missionName), user)
             }.onFailure {
-                addRequestCount()
-                checkRequestCount()
+                checkThrowableMessage(it)
             }
         }
     }
@@ -98,8 +98,7 @@ class MissionsAddViewModel @Inject constructor(
                 _isMissionPosted.postValue(Event(Unit))
             }
             .onFailure {
-                addRequestCount()
-                checkRequestCount()
+                checkThrowableMessage(it)
             }
     }
 
@@ -132,6 +131,18 @@ class MissionsAddViewModel @Inject constructor(
 
     fun checkMissionValid() {
         _checkMissionValidEvent.postValue(Event(Unit))
+    }
+
+    private fun checkThrowableMessage(throwable: Throwable) {
+        when (throwable.message) {
+            ErrorMessage.Offline.message -> {
+                addRequestCount()
+                checkRequestCount()
+            }
+            ErrorMessage.UserInfo.message -> {
+            }
+            else -> Unit
+        }
     }
 
     private fun setNetworkDialogEvent() {

--- a/app/src/main/java/com/ariari/mowoori/ui/register/RegisterViewModel.kt
+++ b/app/src/main/java/com/ariari/mowoori/ui/register/RegisterViewModel.kt
@@ -7,6 +7,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.ariari.mowoori.data.repository.IntroRepository
 import com.ariari.mowoori.ui.register.entity.UserInfo
+import com.ariari.mowoori.util.ErrorMessage
 import com.ariari.mowoori.util.Event
 import com.google.android.gms.tasks.OnCompleteListener
 import com.google.firebase.messaging.FirebaseMessaging
@@ -69,8 +70,7 @@ class RegisterViewModel @Inject constructor(
                     profileText.postValue(nickname)
                 }
                 .onFailure {
-                    addRequestCount()
-                    checkRequestCount()
+                    checkThrowableMessage(it)
                 }
         }
     }
@@ -103,9 +103,8 @@ class RegisterViewModel @Inject constructor(
                     .onSuccess { url ->
                         uploadUrl = url
                     }
-                    .onFailure {
-                        addRequestCount()
-                        checkRequestCount()
+                    .onFailure { throwable ->
+                        checkThrowableMessage(throwable)
                         return@launch
                     }
             }
@@ -120,8 +119,7 @@ class RegisterViewModel @Inject constructor(
                 setLoadingEvent(false)
                 _registerSuccessEvent.postValue(Event(it))
             }.onFailure {
-                addRequestCount()
-                checkRequestCount()
+                checkThrowableMessage(it)
             }
         }
     }
@@ -137,6 +135,16 @@ class RegisterViewModel @Inject constructor(
 
     private fun checkNicknameValid(nickname: String): Boolean {
         return (nickname.length <= 11 && nickname.isNotEmpty())
+    }
+
+    private fun checkThrowableMessage(throwable: Throwable) {
+        when (throwable.message) {
+            ErrorMessage.Offline.message -> {
+                addRequestCount()
+                checkRequestCount()
+            }
+            else -> setLoadingEvent(false)
+        }
     }
 
     private fun setNetworkDialogEvent() {

--- a/app/src/main/java/com/ariari/mowoori/ui/stamp/StampsViewModel.kt
+++ b/app/src/main/java/com/ariari/mowoori/ui/stamp/StampsViewModel.kt
@@ -136,17 +136,12 @@ class StampsViewModel @Inject constructor(
                 addRequestCount()
                 checkRequestCount()
             }
-            ErrorMessage.MissionInfo.message -> {
-            }
-            ErrorMessage.StampInfo.message -> {
-            }
-            else -> Unit
+            else -> setLoadingEvent(false)
         }
     }
 
     private fun setNetworkDialogEvent() {
         setLoadingEvent(false)
-
         _networkDialogEvent.postValue(Event(true))
     }
 

--- a/app/src/main/java/com/ariari/mowoori/ui/stamp/StampsViewModel.kt
+++ b/app/src/main/java/com/ariari/mowoori/ui/stamp/StampsViewModel.kt
@@ -138,11 +138,7 @@ class StampsViewModel @Inject constructor(
             }
             ErrorMessage.MissionInfo.message -> {
             }
-            ErrorMessage.Uid.message -> {
-            }
-            ErrorMessage.GroupId.message -> {
-            }
-            ErrorMessage.GroupInfo.message -> {
+            ErrorMessage.StampInfo.message -> {
             }
             else -> Unit
         }

--- a/app/src/main/java/com/ariari/mowoori/ui/stamp_detail/StampDetailViewModel.kt
+++ b/app/src/main/java/com/ariari/mowoori/ui/stamp_detail/StampDetailViewModel.kt
@@ -10,11 +10,11 @@ import com.ariari.mowoori.ui.missions.entity.Mission
 import com.ariari.mowoori.ui.stamp.entity.DetailInfo
 import com.ariari.mowoori.ui.stamp.entity.DetailMode
 import com.ariari.mowoori.ui.stamp.entity.StampInfo
+import com.ariari.mowoori.util.ErrorMessage
 import com.ariari.mowoori.util.Event
 import com.ariari.mowoori.util.LogUtil
 import com.ariari.mowoori.util.getCurrentDate
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Dispatchers.IO
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
@@ -126,8 +126,7 @@ class StampDetailViewModel @Inject constructor(
                         postStampInfo(uri)
                     }
                     .onFailure {
-                        addRequestCount()
-                        checkRequestCount()
+                        checkThrowableMessage(it)
                     }
             } else {
                 postStampInfo("")
@@ -137,15 +136,25 @@ class StampDetailViewModel @Inject constructor(
 
     fun getGroupMembersFcmToken() {
         viewModelScope.launch(IO) {
-            stampsRepository.getGroupMembersUserId().onSuccess { idList ->
-                val deferredMembersUserIdList = idList.map { userId ->
-                    async { stampsRepository.getGroupMembersFcmToken(userId) }
+            stampsRepository.getGroupMembersUserId()
+                .onSuccess { idList ->
+                    val deferredMembersUserIdList = idList.map { userId ->
+                        async { stampsRepository.getGroupMembersFcmToken(userId) }
+                    }
+                    _groupMembersTokenList.postValue(
+                        deferredMembersUserIdList.awaitAll().map { result ->
+                            if (result.isSuccess) {
+                                result.getOrNull() ?: ""
+                            } else {
+                                val throwable = result.exceptionOrNull() ?: return@launch
+                                checkThrowableMessage(throwable)
+                                return@launch
+                            }
+                        }
+                    )
+                }.onFailure {
+                    checkThrowableMessage(it)
                 }
-                _groupMembersTokenList.postValue(
-                    deferredMembersUserIdList.awaitAll().map { result -> result.getOrNull() ?: "" })
-            }.onFailure {
-                LogUtil.log(it.message.toString())
-            }
         }
     }
 
@@ -164,8 +173,7 @@ class StampDetailViewModel @Inject constructor(
                         LogUtil.log("fcm", it.success.toString())
                         LogUtil.log("fcm", it.failure.toString())
                     }.onFailure {
-                        addRequestCount()
-                        checkRequestCount()
+                        checkThrowableMessage(it)
                         LogUtil.log("fcm", it.message.toString())
                     }
                 }
@@ -186,15 +194,23 @@ class StampDetailViewModel @Inject constructor(
                     .onSuccess {
                         _isStampPosted.postValue(Event(Unit))
                         setLoadingEvent(false)
-                    }.onFailure {
-                        addRequestCount()
-                        checkRequestCount()
+                    }.onFailure { throwable ->
+                        checkThrowableMessage(throwable)
                     }
             }
             .onFailure {
+                checkThrowableMessage(it)
+            }
+    }
+
+    private fun checkThrowableMessage(throwable: Throwable) {
+        when (throwable.message) {
+            ErrorMessage.Offline.message -> {
                 addRequestCount()
                 checkRequestCount()
             }
+            else -> setLoadingEvent(false)
+        }
     }
 
     private fun setNetworkDialogEvent() {

--- a/app/src/main/java/com/ariari/mowoori/util/ErrorMessage.kt
+++ b/app/src/main/java/com/ariari/mowoori/util/ErrorMessage.kt
@@ -1,5 +1,15 @@
 package com.ariari.mowoori.util
 
 enum class ErrorMessage(val message: String) {
-    Offline("Client is offline"), Uid("uid is null"), GroupId("groupId is null"), GroupInfo("groupInfo is null"), MissionInfo("missionInfo is null"), StampInfo("stampInfo is null")
+    Offline("Client is offline"),
+    Uid("uid is null"),
+    UserList("userList is null"),
+    CurrentGroupId("groupId is null"),
+    GroupInfo("groupInfo is null"),
+    MissionInfo("missionInfo is null"),
+    StampInfo("stampInfo is null"),
+    UserInfo("userInfo is null"),
+    Path("invalid path"),
+    HashKey("invalid hash key"),
+    PushKey("Couldn't get push key for posts")
 }

--- a/app/src/main/java/com/ariari/mowoori/util/ErrorMessage.kt
+++ b/app/src/main/java/com/ariari/mowoori/util/ErrorMessage.kt
@@ -1,5 +1,5 @@
 package com.ariari.mowoori.util
 
 enum class ErrorMessage(val message: String) {
-    Offline("Client is offline"), Uid("uid is null"), GroupId("groupId is null"), GroupInfo("groupInfo is null"), MissionInfo("missionInfo is null")
+    Offline("Client is offline"), Uid("uid is null"), GroupId("groupId is null"), GroupInfo("groupInfo is null"), MissionInfo("missionInfo is null"), StampInfo("stampInfo is null")
 }

--- a/app/src/main/java/com/ariari/mowoori/util/ErrorMessage.kt
+++ b/app/src/main/java/com/ariari/mowoori/util/ErrorMessage.kt
@@ -1,5 +1,5 @@
 package com.ariari.mowoori.util
 
 enum class ErrorMessage(val message: String) {
-    Offline("Client is offline"), Uid("uid is null"), GroupId("groupId is null"), GroupInfo("groupInfo is null")
+    Offline("Client is offline"), Uid("uid is null"), GroupId("groupId is null"), GroupInfo("groupInfo is null"), MissionInfo("missionInfo is null")
 }


### PR DESCRIPTION
# ❗️ 이슈 트래킹
- #104 

# 💡 작업목록
- 전체 화면에 대한 네트워크 에러 핸들링 코드 작성

# ❓ 고민과 해결
- 파이어베이스에 setValue 하거나 updateChildren 하는 경우는 네트워크 연결이 끊겨도 재연결을 시도하면 파이어베이스에 값이 저장되는 것을 확인했다. 또한 이전에 유저 정보를 가져오거나 다른 데이터를 선행적으로 가져오면서 네트워크 연결 여부를 확인하기 때문에 별도로 네트워크 에러에 대한 코드는 작성하지 않았다.

