### PR TITLE
[fix] 스탬프 상세화면 에러 수정

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -89,9 +89,14 @@ dependencies {
     implementation "com.google.code.gson:gson:$gsonVersion"
 
     // EncryptedSharedPreferences
-    implementation "androidx.security:security-crypto:1.1.0-alpha03"
+    implementation "androidx.security:security-crypto:$encryptedSharedPreferencesVersion"
 
     // Retrofit
-    implementation 'com.squareup.retrofit2:retrofit:2.9.0'
-    implementation 'com.squareup.retrofit2:converter-gson:2.9.0'
+    implementation "com.squareup.retrofit2:retrofit:$retrofitVersion"
+    implementation "com.squareup.retrofit2:converter-gson:$retrofitVersion"
+
+    // RxJava(RxBinding)
+    implementation "com.jakewharton.rxbinding4:rxbinding:$rxBindingVersion"
+    implementation "com.jakewharton.rxbinding4:rxbinding-core:$rxBindingVersion"
+    implementation "com.jakewharton.rxbinding4:rxbinding-appcompat:$rxBindingVersion"
 }

--- a/app/src/main/java/com/ariari/mowoori/ui/stamp_detail/StampDetailFragment.kt
+++ b/app/src/main/java/com/ariari/mowoori/ui/stamp_detail/StampDetailFragment.kt
@@ -35,9 +35,13 @@ import com.ariari.mowoori.widget.ProgressDialogManager
 import com.bumptech.glide.Glide
 import com.bumptech.glide.load.resource.bitmap.CenterCrop
 import com.bumptech.glide.load.resource.bitmap.RoundedCorners
+import com.jakewharton.rxbinding4.view.clicks
 import dagger.hilt.android.AndroidEntryPoint
+import io.reactivex.rxjava3.android.schedulers.AndroidSchedulers
+import io.reactivex.rxjava3.disposables.Disposable
 import timber.log.Timber
 import java.io.File
+import java.util.concurrent.TimeUnit
 
 @AndroidEntryPoint
 class StampDetailFragment :
@@ -46,6 +50,7 @@ class StampDetailFragment :
     private val safeArgs: StampDetailFragmentArgs by navArgs()
     private var currentPhotoPath: String? = null
     private var providerUri: Uri? = null
+    private var completeBtnDisposable: Disposable? = null
 
     private val activityGalleryLauncher =
         registerForActivityResult(ActivityResultContracts.GetContent()) {
@@ -185,15 +190,17 @@ class StampDetailFragment :
     }
 
     private fun setBtnCertifyListener() {
-        binding.btnStampDetailCertify.setOnClickListener {
-            stampDetailViewModel.setComment(binding.etStampDetailComment.text.toString())
-            if (requireContext().isNetWorkAvailable()) {
-                stampDetailViewModel.setLoadingEvent(true)
-                stampDetailViewModel.postStamp()
-            } else {
-                showNetworkDialog()
+        completeBtnDisposable = binding.btnStampDetailCertify.clicks()
+            .throttleFirst(5, TimeUnit.SECONDS, AndroidSchedulers.mainThread())
+            .observeOn(AndroidSchedulers.mainThread())
+            .subscribe {
+                stampDetailViewModel.setComment(binding.etStampDetailComment.text.toString())
+                if (requireContext().isNetWorkAvailable()) {
+                    stampDetailViewModel.setLoadingEvent(true)
+                } else {
+                    showNetworkDialog()
+                }
             }
-        }
     }
 
     private val onClick: (pictureType: PictureType) -> Unit = {
@@ -330,8 +337,10 @@ class StampDetailFragment :
 
     private fun setLoadingObserver() {
         stampDetailViewModel.loadingEvent.observe(viewLifecycleOwner, EventObserver { isLoading ->
-            if (isLoading) ProgressDialogManager.instance.show(requireContext())
-            else ProgressDialogManager.instance.clear()
+            if (isLoading) {
+                ProgressDialogManager.instance.show(requireContext())
+                stampDetailViewModel.postStamp()
+            } else ProgressDialogManager.instance.clear()
         })
     }
 
@@ -355,5 +364,10 @@ class StampDetailFragment :
                 stampDetailViewModel.postStamp()
             }
         }).show(requireActivity().supportFragmentManager, "NetworkDialogFragment")
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        completeBtnDisposable?.dispose()
     }
 }

--- a/app/src/main/java/com/ariari/mowoori/ui/stamp_detail/StampDetailFragment.kt
+++ b/app/src/main/java/com/ariari/mowoori/ui/stamp_detail/StampDetailFragment.kt
@@ -260,19 +260,15 @@ class StampDetailFragment :
         stampDetailViewModel.setPictureUri(uri)
 
         if (uri == null) {
-            Glide.with(requireContext())
-                .load(R.drawable.ic_stamp)
-                .override(300, 300)
-                .transform(CenterCrop(), RoundedCorners(16))
-                .into(binding.ivStampDetail)
+            binding.tvStampDetailIcon.isVisible = true
         } else {
             Glide.with(requireContext())
                 .load(uri)
                 .override(300, 300)
                 .transform(CenterCrop(), RoundedCorners(16))
                 .into(binding.ivStampDetail)
+            binding.tvStampDetailIcon.isVisible = false
         }
-        binding.tvStampDetailIcon.isVisible = false
     }
 
     private fun hasPermission(permission: String): Boolean {

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,6 @@ buildscript {
         firebaseBomVersion = '28.4.1'
         googleAuthVersion = '19.2.0'
         glideVersion = '4.12.0'
-
         junitVersion = '4.13.2'
         extJunitVersion = '1.1.3'
         espressoVersion = '3.4.0'
@@ -21,6 +20,9 @@ buildscript {
         coroutineVersion = '1.5.0'
         coroutinePlayServices = '1.1.1'
         gsonVersion = '2.8.9'
+        rxBindingVersion = '4.0.0'
+        retrofitVersion ='2.9.0'
+        encryptedSharedPreferencesVersion = '1.1.0-alpha03'
     }
     repositories {
         google()


### PR DESCRIPTION
# ❗️ 이슈 트래킹
- #127 

# 💡 작업목록
- 스탬프 인증 시 무한로딩 문제 해결
- 스탬프 기본 도장이미지로 안바뀌게 설정

# ❓ 고민과 해결
- 무한로딩을 발생시키는 원인을 처음에는 LoadingEvent의 호출순서 때문이라고 생각하고 바꾸었지만 여전히 인증버튼이 클릭이 여러번 되는 것을 확인하였다. 그래서 클릭을 1번만 되도록 막아야겠다고 생각하였다.
- RxJava를 사용하는 RxBinding이라는 라이브러리를 사용하여 throttle 기능을 버튼에 구현하여 5초동안은 클릭이벤트를 발생시키지 않도록 설정하였더니 정상적으로 잘 동작하는 것 같다.

