### PR TITLE
[fix] 리사이클러뷰 overscrollmode 설정 및 드로우어 레이아웃 리사이클러뷰 영역 수정

### DIFF
--- a/app/src/main/res/drawable/border_sky_blue_line_oval.xml
+++ b/app/src/main/res/drawable/border_sky_blue_line_oval.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <shape xmlns:android="http://schemas.android.com/apk/res/android"
     android:shape="oval">
-    <solid android:color="@color/transparent" />
+    <solid android:color="@color/white" />
     <stroke android:color="@color/sky_blue_2094FF"
         android:width="2dp"/>
 </shape>

--- a/app/src/main/res/layout/fragment_home.xml
+++ b/app/src/main/res/layout/fragment_home.xml
@@ -234,6 +234,7 @@
                 android:id="@+id/rv_drawer"
                 android:layout_width="match_parent"
                 android:layout_height="0dp"
+                android:overScrollMode="never"
                 app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintTop_toBottomOf="@id/layout_drawer_header"

--- a/app/src/main/res/layout/fragment_home.xml
+++ b/app/src/main/res/layout/fragment_home.xml
@@ -221,7 +221,7 @@
         </androidx.constraintlayout.widget.ConstraintLayout>
 
         <androidx.constraintlayout.widget.ConstraintLayout
-            android:layout_width="wrap_content"
+            android:layout_width="match_parent"
             android:layout_height="match_parent"
             android:layout_gravity="start"
             android:background="@color/white">

--- a/app/src/main/res/layout/fragment_members.xml
+++ b/app/src/main/res/layout/fragment_members.xml
@@ -22,8 +22,8 @@
             android:layout_height="wrap_content"
             app:layout_constraintTop_toTopOf="parent"
             app:onInviteClick="@{viewModel::clickPlusButton}"
-            app:titleViewText="@{viewModel.currentGroup.groupInfo.groupName}"
-            app:titleViewMode="@{TitleViewMode.TITLE_VIEW_INVITE_BUTTON}" />
+            app:titleViewMode="@{TitleViewMode.TITLE_VIEW_INVITE_BUTTON}"
+            app:titleViewText="@{viewModel.currentGroup.groupInfo.groupName}" />
 
         <androidx.recyclerview.widget.RecyclerView
             android:id="@+id/rv_members"
@@ -31,6 +31,7 @@
             android:layout_height="0dp"
             android:layout_marginHorizontal="18dp"
             android:orientation="vertical"
+            android:overScrollMode="never"
             app:layoutManager="androidx.recyclerview.widget.GridLayoutManager"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"

--- a/app/src/main/res/layout/fragment_missions.xml
+++ b/app/src/main/res/layout/fragment_missions.xml
@@ -118,6 +118,7 @@
             android:layout_width="match_parent"
             android:layout_height="0dp"
             android:layout_marginTop="16dp"
+            android:overScrollMode="never"
             app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"

--- a/app/src/main/res/layout/fragment_notification.xml
+++ b/app/src/main/res/layout/fragment_notification.xml
@@ -13,14 +13,6 @@
         android:layout_height="match_parent"
         tools:context=".ui.notification.NotificationFragment">
 
-        <androidx.recyclerview.widget.RecyclerView
-            android:id="@+id/rv_notification"
-            android:layout_width="match_parent"
-            android:layout_height="0dp"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent" />
-
         <TextView
             android:id="@+id/tv_notification_nothing"
             android:layout_width="wrap_content"

--- a/app/src/main/res/layout/fragment_stamps.xml
+++ b/app/src/main/res/layout/fragment_stamps.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <layout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto">
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
 
     <data>
 
@@ -28,23 +29,37 @@
             app:titleViewMode="@{TitleViewMode.TITLE_VIEW_BACK_BUTTON}"
             app:titleViewText="@{viewModel.mission.missionInfo.missionName}" />
 
-        <androidx.recyclerview.widget.RecyclerView
-            android:id="@+id/rv_stamps"
-            android:layout_width="match_parent"
+        <View
+            android:id="@+id/view_stamps"
+            android:layout_width="0dp"
             android:layout_height="0dp"
-            android:layout_margin="32dp"
-            android:padding="10dp"
-            app:layoutManager="androidx.recyclerview.widget.GridLayoutManager"
+            android:layout_margin="20dp"
+            android:background="@drawable/border_sky_blue_f2f6ff_fill_16"
             app:layout_constraintBottom_toTopOf="@id/btn_stamps_complete"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/title_view_stamps" />
 
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/rv_stamps"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            android:layout_marginHorizontal="12dp"
+            android:clipToPadding="false"
+            android:overScrollMode="never"
+            android:paddingHorizontal="10dp"
+            android:paddingVertical="22dp"
+            app:layoutManager="androidx.recyclerview.widget.GridLayoutManager"
+            app:layout_constraintTop_toTopOf="@id/view_stamps"
+            app:layout_constraintEnd_toEndOf="@id/view_stamps"
+            app:layout_constraintStart_toStartOf="@id/view_stamps"
+            app:layout_constraintBottom_toBottomOf="@id/view_stamps" />
+
         <androidx.appcompat.widget.AppCompatButton
             android:id="@+id/btn_stamps_complete"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginBottom="24dp"
+            android:layout_marginVertical="20dp"
             android:background="@drawable/border_sky_blue_line_30"
             android:padding="12dp"
             android:text="@string/stamps_complete"


### PR DESCRIPTION
# ❗️ 이슈 트래킹
- #136 

# 💡 작업목록
- DrawerLayout 영역 수정하여 리사이클러뷰 너비 고정
- StampFragment 스탬프 리스트 스크롤 영역 부자연스러웠던 부분 해결
- 리사이클러뷰 overScrollMode 설정하여 스크롤 시 그림자 제거

