### PR TITLE
[fix] 로그인 전 네트워크 오류 시 앱 종료 및 그룹 & 닉네임 중복 검사

### DIFF
--- a/app/src/main/java/com/ariari/mowoori/data/repository/GroupRepository.kt
+++ b/app/src/main/java/com/ariari/mowoori/data/repository/GroupRepository.kt
@@ -7,6 +7,8 @@ import com.ariari.mowoori.ui.register.entity.User
 interface GroupRepository {
     suspend fun getGroupInfo(groupId: String): Result<GroupInfo>
 
+    suspend fun isGroupNameExist(groupName: String): Result<Boolean>
+
     fun putGroupInfo(groupInfo: GroupInfo, user: User): Result<String>
 
     suspend fun addUserToGroup(groupId: String, user: User): Result<String>

--- a/app/src/main/java/com/ariari/mowoori/data/repository/GroupRepository.kt
+++ b/app/src/main/java/com/ariari/mowoori/data/repository/GroupRepository.kt
@@ -7,7 +7,7 @@ import com.ariari.mowoori.ui.register.entity.User
 interface GroupRepository {
     suspend fun getGroupInfo(groupId: String): Result<GroupInfo>
 
-    suspend fun getGroupNameList(groupName: String): Result<List<String>>
+    suspend fun getGroupNameList(): Result<List<String>>
 
     fun putGroupInfo(groupNameList: List<String>, groupInfo: GroupInfo, user: User): Result<String>
 

--- a/app/src/main/java/com/ariari/mowoori/data/repository/GroupRepository.kt
+++ b/app/src/main/java/com/ariari/mowoori/data/repository/GroupRepository.kt
@@ -7,9 +7,9 @@ import com.ariari.mowoori.ui.register.entity.User
 interface GroupRepository {
     suspend fun getGroupInfo(groupId: String): Result<GroupInfo>
 
-    suspend fun isGroupNameExist(groupName: String): Result<Boolean>
+    suspend fun getGroupNameList(groupName: String): Result<List<String>>
 
-    fun putGroupInfo(groupInfo: GroupInfo, user: User): Result<String>
+    fun putGroupInfo(groupNameList: List<String>, groupInfo: GroupInfo, user: User): Result<String>
 
     suspend fun addUserToGroup(groupId: String, user: User): Result<String>
 

--- a/app/src/main/java/com/ariari/mowoori/data/repository/GroupRepositoryImpl.kt
+++ b/app/src/main/java/com/ariari/mowoori/data/repository/GroupRepositoryImpl.kt
@@ -22,7 +22,7 @@ class GroupRepositoryImpl @Inject constructor(
             ?: throw NullPointerException(ErrorMessage.GroupInfo.message)
     }
 
-    override suspend fun getGroupNameList(groupName: String): Result<List<String>> = runCatching {
+    override suspend fun getGroupNameList(): Result<List<String>> = runCatching {
         val groupNameListSnapShot = databaseReference.child("groupNameList").get().await()
         groupNameListSnapShot.getValue(object : GenericTypeIndicator<List<String>>() {})
             ?: emptyList()

--- a/app/src/main/java/com/ariari/mowoori/data/repository/IntroRepository.kt
+++ b/app/src/main/java/com/ariari/mowoori/data/repository/IntroRepository.kt
@@ -16,7 +16,9 @@ interface IntroRepository {
 
     fun getUserUid(): String?
 
-    suspend fun userRegister(userInfo: UserInfo): Result<Boolean>
+    suspend fun getUserNameList(): Result<List<String>>
+
+    suspend fun registerUser(userNameList: List<String>, userInfo: UserInfo): Result<Boolean>
 
     suspend fun putUserProfile(uri: Uri): Result<String>
 

--- a/app/src/main/java/com/ariari/mowoori/ui/group/GroupFragment.kt
+++ b/app/src/main/java/com/ariari/mowoori/ui/group/GroupFragment.kt
@@ -6,6 +6,7 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.core.view.isInvisible
 import androidx.core.view.isVisible
 import androidx.core.widget.doOnTextChanged
 import androidx.fragment.app.DialogFragment
@@ -75,11 +76,9 @@ class GroupFragment : Fragment() {
     }
 
     private fun setValidationObserver() {
-        viewModel.inValidEvent.observe(viewLifecycleOwner, EventObserver {
-            when (args.groupMode) {
-                GroupMode.INVITE -> binding.tvInviteCodeInvalid.isVisible = true
-                GroupMode.NEW -> binding.tvGroupNameInvalid.isVisible = true
-            }
+        viewModel.inValidMode.observe(viewLifecycleOwner, {
+            binding.tvInvalid.isVisible = true
+            binding.tvInvalid.text = it.message
             objectAnimator.start()
         })
     }
@@ -92,8 +91,7 @@ class GroupFragment : Fragment() {
 
     private fun setGroupNameChangeListener() {
         binding.etGroup.doOnTextChanged { _, _, _, _ ->
-            binding.tvGroupNameInvalid.isVisible = false
-            binding.tvInviteCodeInvalid.isVisible = false
+            binding.tvInvalid.isInvisible = true
         }
     }
 

--- a/app/src/main/java/com/ariari/mowoori/ui/group/GroupViewModel.kt
+++ b/app/src/main/java/com/ariari/mowoori/ui/group/GroupViewModel.kt
@@ -6,7 +6,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.ariari.mowoori.data.repository.GroupRepository
 import com.ariari.mowoori.data.repository.IntroRepository
-import com.ariari.mowoori.ui.group.entity.InvalidMode
+import com.ariari.mowoori.util.InvalidMode
 import com.ariari.mowoori.ui.home.entity.GroupInfo
 import com.ariari.mowoori.ui.register.entity.User
 import com.ariari.mowoori.util.ErrorMessage
@@ -115,7 +115,7 @@ class GroupViewModel @Inject constructor(
 
     private suspend fun checkGroupNameExist(name: String, user: User) {
         initRequestCount()
-        groupRepository.getGroupNameList(name)
+        groupRepository.getGroupNameList()
             .onSuccess { groupNameList ->
                 val groupInfo = GroupInfo(0, name, listOf(user.userId))
                 initRequestCount()

--- a/app/src/main/java/com/ariari/mowoori/ui/group/entity/InvalidMode.kt
+++ b/app/src/main/java/com/ariari/mowoori/ui/group/entity/InvalidMode.kt
@@ -1,8 +1,0 @@
-package com.ariari.mowoori.ui.group.entity
-
-enum class InvalidMode(val message: String) {
-    AlreadyJoin("이미 해당 그룹의 구성원입니다!"),
-    InValidCode("유효하지 않은 코드입니다!"),
-    InValidGroupName("1자 이상 11자 이하로 입력해주세요!"),
-    AlreadyExistGroupName("이미 존재하는 그룹 이름입니다!")
-}

--- a/app/src/main/java/com/ariari/mowoori/ui/group/entity/InvalidMode.kt
+++ b/app/src/main/java/com/ariari/mowoori/ui/group/entity/InvalidMode.kt
@@ -1,0 +1,8 @@
+package com.ariari.mowoori.ui.group.entity
+
+enum class InvalidMode(val message: String) {
+    AlreadyJoin("이미 해당 그룹의 구성원입니다!"),
+    InValidCode("유효하지 않은 코드입니다!"),
+    InValidGroupName("1자 이상 11자 이하로 입력해주세요!"),
+    AlreadyExistGroupName("이미 존재하는 그룹 이름입니다!")
+}

--- a/app/src/main/java/com/ariari/mowoori/ui/intro/IntroActivity.kt
+++ b/app/src/main/java/com/ariari/mowoori/ui/intro/IntroActivity.kt
@@ -22,6 +22,7 @@ import com.ariari.mowoori.util.toastMessage
 import com.ariari.mowoori.widget.NetworkDialogFragment
 import dagger.hilt.android.AndroidEntryPoint
 import timber.log.Timber
+import kotlin.system.exitProcess
 
 @AndroidEntryPoint
 class IntroActivity : AppCompatActivity() {
@@ -156,9 +157,9 @@ class IntroActivity : AppCompatActivity() {
         registerForActivityResult(ActivityResultContracts.RequestMultiplePermissions()) { permissions: Map<String, Boolean>? ->
             Timber.d("register까지 잘 들어왔음")
             permissions?.let {
-                it.entries.forEach { it ->
-                    val permissionName = it.key
-                    val isGranted = it.value
+                it.entries.forEach { map ->
+                    val permissionName = map.key
+                    val isGranted = map.value
                     if (isGranted) {
                         LogUtil.log("permissionName", permissionName)
 //                    when (permissionName) {
@@ -185,6 +186,9 @@ class IntroActivity : AppCompatActivity() {
         NetworkDialogFragment(object : NetworkDialogFragment.NetworkDialogListener {
             override fun onCancelClick(dialog: DialogFragment) {
                 dialog.dismiss()
+                finishAffinity()
+                System.runFinalization()
+                exitProcess(0)
             }
 
             override fun onRetryClick(dialog: DialogFragment) {

--- a/app/src/main/java/com/ariari/mowoori/ui/register/RegisterActivity.kt
+++ b/app/src/main/java/com/ariari/mowoori/ui/register/RegisterActivity.kt
@@ -1,17 +1,12 @@
 package com.ariari.mowoori.ui.register
 
-import android.app.Activity
 import android.content.Intent
 import android.os.Bundle
-import android.view.View
-import android.view.inputmethod.InputMethodManager
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.DialogFragment
-import androidx.navigation.fragment.findNavController
 import com.ariari.mowoori.R
-import com.ariari.mowoori.data.local.datasource.MoWooriPrefDataSource
 import com.ariari.mowoori.databinding.ActivityRegisterBinding
 import com.ariari.mowoori.ui.main.MainActivity
 import com.ariari.mowoori.util.EventObserver
@@ -23,7 +18,7 @@ import com.ariari.mowoori.widget.ConfirmDialogFragment
 import com.ariari.mowoori.widget.NetworkDialogFragment
 import com.ariari.mowoori.widget.ProgressDialogManager
 import dagger.hilt.android.AndroidEntryPoint
-import javax.inject.Inject
+import kotlin.system.exitProcess
 
 @AndroidEntryPoint
 class RegisterActivity : AppCompatActivity() {
@@ -142,6 +137,9 @@ class RegisterActivity : AppCompatActivity() {
         NetworkDialogFragment(object : NetworkDialogFragment.NetworkDialogListener {
             override fun onCancelClick(dialog: DialogFragment) {
                 dialog.dismiss()
+                finishAffinity()
+                System.runFinalization()
+                exitProcess(0)
             }
 
             override fun onRetryClick(dialog: DialogFragment) {

--- a/app/src/main/java/com/ariari/mowoori/ui/register/RegisterActivity.kt
+++ b/app/src/main/java/com/ariari/mowoori/ui/register/RegisterActivity.kt
@@ -85,8 +85,8 @@ class RegisterActivity : AppCompatActivity() {
     }
 
     private fun setInvalidNickNameObserver() {
-        registerViewModel.invalidNicknameEvent.observe(this, EventObserver {
-            toastMessage(getString(R.string.register_nickname_error_msg))
+        registerViewModel.invalidNicknameEvent.observe(this, {
+            toastMessage(it.message)
         })
     }
 

--- a/app/src/main/java/com/ariari/mowoori/util/ErrorMessage.kt
+++ b/app/src/main/java/com/ariari/mowoori/util/ErrorMessage.kt
@@ -12,5 +12,6 @@ enum class ErrorMessage(val message: String) {
     Path("invalid path"),
     HashKey("invalid hash key"),
     PushKey("Couldn't get push key for posts"),
-    DuplicatedGroup("Group Duplication is not allowed")
+    DuplicatedGroup("Group Duplication is not allowed"),
+    ExistGroupName("group name already exists")
 }

--- a/app/src/main/java/com/ariari/mowoori/util/ErrorMessage.kt
+++ b/app/src/main/java/com/ariari/mowoori/util/ErrorMessage.kt
@@ -11,5 +11,6 @@ enum class ErrorMessage(val message: String) {
     UserInfo("userInfo is null"),
     Path("invalid path"),
     HashKey("invalid hash key"),
-    PushKey("Couldn't get push key for posts")
+    PushKey("Couldn't get push key for posts"),
+    DuplicatedGroup("Group Duplication is not allowed")
 }

--- a/app/src/main/java/com/ariari/mowoori/util/ErrorMessage.kt
+++ b/app/src/main/java/com/ariari/mowoori/util/ErrorMessage.kt
@@ -13,5 +13,6 @@ enum class ErrorMessage(val message: String) {
     HashKey("invalid hash key"),
     PushKey("Couldn't get push key for posts"),
     DuplicatedGroup("Group Duplication is not allowed"),
-    ExistGroupName("group name already exists")
+    ExistGroupName("group name already exists"),
+    ExistUserName("user name already exists")
 }

--- a/app/src/main/java/com/ariari/mowoori/util/InvalidMode.kt
+++ b/app/src/main/java/com/ariari/mowoori/util/InvalidMode.kt
@@ -1,0 +1,10 @@
+package com.ariari.mowoori.util
+
+enum class InvalidMode(val message: String) {
+    AlreadyJoin("이미 해당 그룹의 구성원입니다!"),
+    InValidCode("유효하지 않은 코드입니다!"),
+    InValidGroupName("1자 이상 11자 이하로 입력해주세요!"),
+    AlreadyExistGroupName("이미 존재하는 그룹 이름입니다!"),
+    AlreadyExistNickname("이미 존재하는 닉네임입니다!"),
+    InvalidNickname("1자 이상 10자 이하로 입력해주세요!")
+}

--- a/app/src/main/res/layout/fragment_group.xml
+++ b/app/src/main/res/layout/fragment_group.xml
@@ -49,23 +49,11 @@
             tools:ignore="LabelFor" />
 
         <TextView
-            android:id="@+id/tv_invite_code_invalid"
+            android:id="@+id/tv_invalid"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginTop="4dp"
             android:text="@string/group_invite_invalid"
-            android:textColor="@color/red_FF0000"
-            android:textSize="16sp"
-            android:visibility="invisible"
-            app:layout_constraintStart_toStartOf="@id/et_group"
-            app:layout_constraintTop_toBottomOf="@id/et_group" />
-
-        <TextView
-            android:id="@+id/tv_group_name_invalid"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="4dp"
-            android:text="@string/group_name_invalid"
             android:textColor="@color/red_FF0000"
             android:textSize="16sp"
             android:visibility="invisible"

--- a/app/src/main/res/xml/fragment_group_xml_constraintlayout_scene.xml
+++ b/app/src/main/res/xml/fragment_group_xml_constraintlayout_scene.xml
@@ -36,10 +36,14 @@
     </Transition>
 
     <ConstraintSet android:id="@+id/start">
-
+        <Constraint android:id="@id/tv_invalid">
+            <PropertySet motion:visibilityMode="ignore" />
+        </Constraint>
     </ConstraintSet>
 
     <ConstraintSet android:id="@+id/end">
-
+        <Constraint android:id="@id/tv_invalid">
+            <PropertySet motion:visibilityMode="ignore" />
+        </Constraint>
     </ConstraintSet>
 </MotionScene>


### PR DESCRIPTION
# ❗️ 이슈 트래킹
- #132 

# 💡 작업목록
- 인트로 화면에서 네트워크 오류 시 앱 종료
- 회원가입 화면에서 네트워크 오류 시 앱 종료
- 이미 등록한 초대 코드 입력 방지
- 동일한 그룹 이름 등록 방지
- 동일한 닉네임 등록 방지

# ❓ 고민과 해결
- 액티비티를 단순히 종료하면 프로세스는 살아있어서 application 의 onCreate 콜백이 실행되지 않았다. 
-> exitProcess(0) 을 통해 프로세스까지 완전히 종료시켰다.
