### PR TITLE
[fix] FCM 알림 클릭 후 앱 열었을 시 상세 정보 안뜨는 에러 해결

### DIFF
--- a/app/src/main/java/com/ariari/mowoori/ui/main/MainActivity.kt
+++ b/app/src/main/java/com/ariari/mowoori/ui/main/MainActivity.kt
@@ -29,7 +29,6 @@ class MainActivity : AppCompatActivity() {
         setContentView(binding.root)
         setNavController()
         setBottomNavVisibility()
-        isOpenFromFcm()
     }
 
     private fun isOpenFromFcm() {
@@ -39,6 +38,7 @@ class MainActivity : AppCompatActivity() {
                         HomeFragmentDirections.actionHomeFragmentToStampDetailFragment(detailInfo)
                     )
             }
+            intent.removeExtra(FROM_FCM)
         }
     }
 
@@ -53,7 +53,11 @@ class MainActivity : AppCompatActivity() {
     private fun setBottomNavVisibility() {
         navController.addOnDestinationChangedListener { _, destination, arguments ->
             when (destination.id) {
-                R.id.homeFragment, R.id.membersFragment -> showBottomNav()
+                R.id.homeFragment->{
+                    isOpenFromFcm()
+                    showBottomNav()
+                }
+                R.id.membersFragment -> showBottomNav()
                 R.id.missionsFragment -> {
                     if (arguments?.get("user") != null) {
                         // 구성원의 미션

--- a/app/src/main/java/com/ariari/mowoori/ui/stamp_detail/StampDetailViewModel.kt
+++ b/app/src/main/java/com/ariari/mowoori/ui/stamp_detail/StampDetailViewModel.kt
@@ -196,7 +196,7 @@ class StampDetailViewModel @Inject constructor(
             initRequestCount()
             stampsRepository.getMissionInfo(detailInfo.missionId)
                 .onSuccess { missionInfo ->
-                    val stampInfo = StampInfo(uriString, comment.value!!, getCurrentDate())
+                    stampInfo = StampInfo(uriString, comment.value!!, getCurrentDate())
                     initRequestCount()
                     stampsRepository.postStamp(
                         stampInfo,

--- a/app/src/main/res/layout/activity_intro.xml
+++ b/app/src/main/res/layout/activity_intro.xml
@@ -113,9 +113,8 @@
 
         <TextView
             android:id="@+id/test"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="Debug"
+            android:layout_width="80dp"
+            android:layout_height="20dp"
             android:visibility="invisible"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent" />


### PR DESCRIPTION
# ❗️ 이슈 트래킹
- #153

# 💡 작업목록
- FCM 알림 클릭 후 앱 열었을 시 상세 정보 안뜨는 에러 해결
- 푸쉬알람으로 앱 열었을 시 상세정보화면으로 navigate 위치 수정
- 테스트 아이디 visibility 처리 텍스트 뷰 투명하게 수정


