### PR TITLE
[fix] FCM으로 앱 켰을 경우 popBackStack으로 Home 돌아왔을 때 Lv3, Lv4애니메이션 위치 틀어지는 문제 해결

### DIFF
--- a/app/src/main/java/com/ariari/mowoori/ui/home/HomeFragment.kt
+++ b/app/src/main/java/com/ariari/mowoori/ui/home/HomeFragment.kt
@@ -73,6 +73,7 @@ class HomeFragment : BaseFragment<FragmentHomeBinding>(R.layout.fragment_home) {
     }
 
     private fun setAnimators() {
+        homeViewModel.cancelAnimator()
         snowAnimator = SnowAnimator(
             container = binding.containerHome,
             addAnimator = { animator -> addSnowAnimator(animator) },

--- a/app/src/main/java/com/ariari/mowoori/ui/home/HomeFragment.kt
+++ b/app/src/main/java/com/ariari/mowoori/ui/home/HomeFragment.kt
@@ -24,8 +24,10 @@ import com.ariari.mowoori.ui.home.animator.SnowmanLv4Animator.Companion.RESET_AL
 import com.ariari.mowoori.ui.home.animator.SnowmanLv4Animator.Companion.RIGHT_BLACK_DONE
 import com.ariari.mowoori.ui.home.animator.SnowmanLv4Animator.Companion.RIGHT_WHITE_DONE
 import com.ariari.mowoori.ui.home.entity.Lv4Component
+import com.ariari.mowoori.ui.stamp.entity.DetailInfo
 import com.ariari.mowoori.util.EventObserver
 import com.ariari.mowoori.util.LogUtil
+import com.ariari.mowoori.util.MowooriMessagingService
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.cancelAndJoin
@@ -73,7 +75,8 @@ class HomeFragment : BaseFragment<FragmentHomeBinding>(R.layout.fragment_home) {
     }
 
     private fun setAnimators() {
-        homeViewModel.cancelAnimator()
+        LogUtil.log("lv3_body",binding.ivHomeSnowmanBody.toString())
+        LogUtil.log("lv3_face",binding.ivHomeSnowmanFaceLv3.toString())
         snowAnimator = SnowAnimator(
             container = binding.containerHome,
             addAnimator = { animator -> addSnowAnimator(animator) },

--- a/app/src/main/java/com/ariari/mowoori/ui/home/animator/SnowAnimator.kt
+++ b/app/src/main/java/com/ariari/mowoori/ui/home/animator/SnowAnimator.kt
@@ -10,7 +10,6 @@ import android.view.animation.AccelerateInterpolator
 import android.widget.ImageView
 import androidx.constraintlayout.widget.ConstraintLayout
 import com.ariari.mowoori.R
-import com.ariari.mowoori.ui.home.HomeViewModel
 import kotlinx.coroutines.delay
 import kotlin.random.Random
 

--- a/app/src/main/java/com/ariari/mowoori/ui/home/animator/SnowmanLv2Animator.kt
+++ b/app/src/main/java/com/ariari/mowoori/ui/home/animator/SnowmanLv2Animator.kt
@@ -8,7 +8,6 @@ import android.content.Context
 import android.view.View
 import android.widget.ImageView
 import com.ariari.mowoori.R
-import com.ariari.mowoori.ui.home.HomeViewModel
 
 class SnowmanLv2Animator(
     private var face: ImageView,

--- a/app/src/main/java/com/ariari/mowoori/ui/home/animator/SnowmanLv3Animator.kt
+++ b/app/src/main/java/com/ariari/mowoori/ui/home/animator/SnowmanLv3Animator.kt
@@ -15,6 +15,7 @@ import android.view.animation.DecelerateInterpolator
 import android.widget.ImageView
 import com.ariari.mowoori.R
 import com.ariari.mowoori.ui.home.entity.ViewInfo
+import com.ariari.mowoori.util.LogUtil
 
 class SnowmanLv3Animator(
     private var face: ImageView,
@@ -122,6 +123,11 @@ class SnowmanLv3Animator(
                 face.x = (body.x - face.width) / 2
                 face.y = body.y + (body.height - face.height)
                 faceInfo = ViewInfo(face.x, face.y, face.width.toFloat(), face.height.toFloat())
+                LogUtil.log("lv3_body",bodyInfo.toString())
+                LogUtil.log("lv3_face",faceInfo.toString())
+                LogUtil.log("lv3_body",body.toString())
+                LogUtil.log("lv3_face",face.toString())
+
                 initHorizontalAnimator()
                 startFirstAnimation()
             }

--- a/app/src/main/java/com/ariari/mowoori/ui/home/animator/SnowmanLv3Animator.kt
+++ b/app/src/main/java/com/ariari/mowoori/ui/home/animator/SnowmanLv3Animator.kt
@@ -14,7 +14,6 @@ import android.view.animation.BounceInterpolator
 import android.view.animation.DecelerateInterpolator
 import android.widget.ImageView
 import com.ariari.mowoori.R
-import com.ariari.mowoori.ui.home.HomeViewModel
 import com.ariari.mowoori.ui.home.entity.ViewInfo
 
 class SnowmanLv3Animator(

--- a/app/src/main/java/com/ariari/mowoori/ui/home/animator/SnowmanLv4Animator.kt
+++ b/app/src/main/java/com/ariari/mowoori/ui/home/animator/SnowmanLv4Animator.kt
@@ -12,7 +12,6 @@ import android.view.View
 import android.view.ViewTreeObserver
 import androidx.core.view.isInvisible
 import com.ariari.mowoori.R
-import com.ariari.mowoori.ui.home.HomeViewModel
 import com.ariari.mowoori.ui.home.entity.Lv4Component
 import com.ariari.mowoori.ui.home.entity.ViewInfo
 

--- a/app/src/main/java/com/ariari/mowoori/ui/main/MainActivity.kt
+++ b/app/src/main/java/com/ariari/mowoori/ui/main/MainActivity.kt
@@ -35,8 +35,11 @@ class MainActivity : AppCompatActivity() {
         if (intent.getBooleanExtra(FROM_FCM, false)) {
             intent.getParcelableExtra<DetailInfo>(DETAIL_INFO)?.let { detailInfo ->
                 navController.navigate(
-                        HomeFragmentDirections.actionHomeFragmentToStampDetailFragment(detailInfo)
+                    HomeFragmentDirections.actionHomeFragmentToStampDetailFragment(
+                        openFromFcm = true,
+                        detailInfo = detailInfo
                     )
+                )
             }
             intent.removeExtra(FROM_FCM)
         }
@@ -53,7 +56,7 @@ class MainActivity : AppCompatActivity() {
     private fun setBottomNavVisibility() {
         navController.addOnDestinationChangedListener { _, destination, arguments ->
             when (destination.id) {
-                R.id.homeFragment->{
+                R.id.homeFragment -> {
                     isOpenFromFcm()
                     showBottomNav()
                 }

--- a/app/src/main/java/com/ariari/mowoori/ui/stamp/StampsFragment.kt
+++ b/app/src/main/java/com/ariari/mowoori/ui/stamp/StampsFragment.kt
@@ -82,7 +82,7 @@ class StampsFragment : BaseFragment<FragmentStampsBinding>(R.layout.fragment_sta
                 this@StampsFragment.findNavController()
                     .navigate(
                         StampsFragmentDirections.actionStampsFragmentToStampDetailFragment(
-                            DetailInfo(
+                            detailInfo = DetailInfo(
                                 user.userInfo.nickname,
                                 mission.missionId,
                                 mission.missionInfo.missionName,
@@ -117,7 +117,7 @@ class StampsFragment : BaseFragment<FragmentStampsBinding>(R.layout.fragment_sta
             it.findNavController()
                 .navigate(
                     StampsFragmentDirections.actionStampsFragmentToStampDetailFragment(
-                        DetailInfo(
+                        detailInfo = DetailInfo(
                             user.userInfo.nickname,
                             mission.missionId,
                             mission.missionInfo.missionName,

--- a/app/src/main/java/com/ariari/mowoori/ui/stamp_detail/StampDetailFragment.kt
+++ b/app/src/main/java/com/ariari/mowoori/ui/stamp_detail/StampDetailFragment.kt
@@ -281,7 +281,11 @@ class StampDetailFragment :
 
     private fun setCloseBtnClickObserver() {
         stampDetailViewModel.closeBtnClick.observe(viewLifecycleOwner, {
-            this.findNavController().popBackStack()
+            if (safeArgs.openFromFcm) {
+                findNavController().navigate(R.id.action_stampDetailFragment_to_homeFragment)
+            } else {
+                findNavController().popBackStack()
+            }
         })
     }
 

--- a/app/src/main/res/navigation/main_navigation.xml
+++ b/app/src/main/res/navigation/main_navigation.xml
@@ -89,7 +89,7 @@
         android:id="@+id/missionsAddFragment"
         android:name="com.ariari.mowoori.ui.missionsadd.MissionsAddFragment"
         android:label="MissionsAddFragment"
-        tools:layout="@layout/fragment_missions_add" >
+        tools:layout="@layout/fragment_missions_add">
         <action
             android:id="@+id/action_missionsAddFragment_to_homeFragment"
             app:destination="@id/homeFragment"
@@ -121,6 +121,10 @@
         android:name="com.ariari.mowoori.ui.stamp_detail.StampDetailFragment"
         android:label="StampDetailFragment"
         tools:layout="@layout/fragment_stamp_detail">
+        <argument
+            android:name="openFromFcm"
+            android:defaultValue="false"
+            app:argType="boolean" />
         <argument
             android:name="detailInfo"
             app:argType="com.ariari.mowoori.ui.stamp.entity.DetailInfo" />


### PR DESCRIPTION
# ❗️ 이슈 트래킹
- #163

# 💡 작업목록
- popBackStack()으로 돌아왔을 경우 UI 갱신 안되던 문제였음
- FCM으로 StampDetailFragment 간 경우에는 navigate로 Home으로 돌아오도록 해결

